### PR TITLE
Fix more typos & issues in Chapter 1

### DIFF
--- a/Chapters/1-callouts.pillar
+++ b/Chapters/1-callouts.pillar
@@ -6,7 +6,7 @@ Code sharing and reuse via an FFI is fundamentally different from source code "i
 
 However, if the compiled resources we wish to link to were built with a different language (or even a different compiler of the same language), the bits and bytes may not line up properly when we push arguments, make calls, and retrieve results, due to the different standards that the other code's compiler followed when the borrowed code was produced.  In this case, more detailed bookkeeping must be followed by our language to make ABI translations and ensure that differences in issues such as data alignment, byte ordering, calling conventions, garbage collection, pointer references, and so forth are accounted for.  Without this, we risk not only getting incorrect results \-\- we could crash our process (or even the operating system).
 
-Although in theory FFI interfaces can be defined to link any pair of differing languages, most languages are designed to interact with libraries written in the C language.  This is because C has a long heritage and widespread use, and (importantly) C has a predictable, standardized way to compile functions and structures.  So with Pharo also choosing C as an FFI target we gain two major advantages: first, by basing ourselves on such "standard" formats, we can build tools that simplify interoperability with an extensive array of existing C libraries.  Second, since nearly every other language is doing the same, we can simply join those mutual C-standard ABIs together to form a bridge between different systems \-\- allowing us to program at the source level of a C API.
+While in theory FFI interfaces can be defined to link any pair of differing languages, most languages are designed to interact with libraries written in the C language.  This is because C has a long heritage and widespread use, and (importantly) C has a predictable, standardized way to compile functions and structures.  So with Pharo also choosing C as an FFI target we gain two major advantages: first, by basing ourselves on such "standard" formats, we can build tools that simplify interoperability with an extensive array of existing C libraries.  Second, since nearly every other language is doing the same, we can simply join those mutual C-standard ABIs together to form a bridge between different systems \-\- allowing us to program at the source level of a C API.
 
 This booklet shows one such FFI definition for Pharo: the Unified FFI framework, or uFFI for short.
 
@@ -54,7 +54,7 @@ FFITutorial class >> ticksSinceStart [
 
 where =='libc.so.6'== refers to the current version of the C shared library on our host system.  (We can find out which version we have by entering ==ls -1 /lib/*/libc.so*== in a Linux terminal window.)
 
-To define the same thing on other platforms, we need to replace the =='libc.so.6'== string by e.g., =='libc.dylib'== if we're running on OSX, or =='msvcrt.dll'== if we use Windows. The equivalent definitions for OSX and Windows are then:
+To define the same binding for other platforms, we need to replace the =='libc.so.6'== string by e.g., =='libc.dylib'== if we're running on MacOS, or =='msvcrt.dll'== if we use Windows. The equivalent definitions for MacOS and Windows are then:
 
 [[[language=smalltalk
 FFITutorial class >> ticksSinceStart [
@@ -79,6 +79,7 @@ FFITutorial ticksSinceStart
 If everything works as expected, this expression will return the number of native clock ticks since our Pharo process was launched.
 
 !!! Analyzing the FFI Call-Out
+@OriginalTicksSinceStartBinding
 
 The simple example we ran in the previous section illustrates several important uFFI concepts.
 For starters, let's look at the binding definition again:
@@ -93,33 +94,33 @@ This call-out binding, a Pharo method, is called ==ticksSinceStart== and happens
 Indeed, uFFI does not impose any restrictions as far as how to call your external functions.  This can come in handy for decoupling your methods from underlying C-level implementation details.
 
 We invoke the C function using the Pharo method ==ffiCall:module:==, which is defined by uFFI.  We assemble the message arguments it needs by deconstructing the target C function declaration and referencing the name of the library in which it's defined.  uFFI takes the pieces and performs all the necessary work to make the call-out.  Continuing our example, we see that uFFI:
-- Locates the specified library (==libc==, ==msvcrt==, ...) in our host system,
-- Loads the C library into memory,
-- Indexes the ==clock== function in the library,
-- Transforms and pushes our Pharo arguments onto the stack,
+- Searches for the specified library in our host system,
+- On finding it, loads the C library into memory,
+- Indexes the specified function within the library,
+- Transforms and pushes our Pharo arguments (if any) onto the stack,
 - Performs the call to the C function,
-- And finally transforms the return value (==uint== type) into a Pharo integer object.
+- And finally transforms the return value into a Pharo object.
 
 We said above that we need to "deconstruct" the C function declaration in order to create the first argument in our ==ffiCall:module:== message.  This argument is a Pharo Array of String, where each string element is a piece of the C declaration; we simply list the pieces in the same sequence as the C declaration.  The uFFI makes sense of it, and dynamically creates a C call with this information.
 
-This is best understood by example, so, to continue with our previous example, we render our C declaration in Pharo as:
+This is best understood by example, so, to continue with our previous, we render our C declaration in Pharo as a literal string array, like so:
 
 [[[
 #( uint clock () )
 ]]]
 
-The first element of our array is ==unit==, which is the function return ''type''.  This is followed by the function name, ==clock==.  Following the function name \-\-and note the space!\-\- we embed another Pharo Array to list the formal arguments the C function expects, in order. In this case, ==clock== takes no arguments, so we must provide an empty Array.
+The first element of our array is ==uint==, which is the function return ''type''.  This is followed by the function name, ==clock==.  Following the function name \-\-and note the space!\-\- we embed another Pharo Array to list the formal arguments the C function expects, in order. In this case, ==clock== takes no arguments, so we must provide an empty Array.
 
 Another way to think of it is this: If we look past the outer ==#()== Pharo syntax, what we see inside is our C function prototype, appearing very similar to normal C syntax (but with spaces in unusual places).  uFFI was intentionally defined this way so that in most cases we can simply copy-paste a C function declaration taken from a header file or documentation, add some required spaces, wrap it in ==#()==, and it's ready for use.
 
-Our ==ffiCall:module:== message also takes a second argument (=='libc.so.6'== in our Linux example), which is the name of the library that contains the function.  In many cases we do not need to provide a full path to the file in our host system.  However, it should already be apparent that our bindings can be platform dependent, if the library we need is also platform-dependent.  We will explore how to define bindings in a platform-independent way in the following section.
+Our ==ffiCall:module:== message also takes a second argument (=='libc.so.6'== in our Linux example), which is the name of the library that contains the function.  In many cases we do not need to provide a full path to the file in our host system.  However, it should already be apparent that our bindings can be platform dependent, if the library we need is also platform-dependent.  We will explore how to define bindings in a platform-independent way in a following section.
 
 
 !!! Notes on Value Marshalling
 
 To fully understand the previous example, we still need to explain how the C ==uint== return value (a non-object; a cluster of bytes popped off the stack) gets transformed into a Pharo ==SmallInteger== ''object''.  Remember, C does not understand objects and does not do us the favor of returning values as attributes embedded within an object; we must somehow create an appropriate type of Pharo object, then migrate the C return value to become ''its'' value.  Our code then receives this Pharo object.
 
-This process of converting values between different internal representations is called ''marshalling'', and is, in most cases, managed automatically in Pharo by uFFI.  For example, uFFI internally maps these standard C values to Smalltalk objects:
+This process of converting values between different internal representations is called ''marshalling'', and in most cases is managed automatically in Pharo by uFFI.  For example, uFFI internally maps these standard C values to Smalltalk objects:
 - Types ==int==, ==uint==, ==long==, ==ulong== are mapped to Pharo integers (small or long integers, depending on the platform architecture).
 - Types ==float== and ==double== are mapped to Pharo floats.
 
@@ -188,7 +189,7 @@ MyLibC >> win32ModuleName [
 ]
 ]]]
 
-To use this improved technique, we modify our ''original'' binding method (in Section 1.2) to substitute our library in place of the library name string:
+To use this improved technique, we modify our ''original'' binding method (in *@OriginalTicksSinceStartBinding*) to substitute our library in place of the library name string:
 
 [[[language=smalltalk
 FFITutorial class >> ticksSinceStart [
@@ -288,8 +289,8 @@ Of course, bindings defining a library explicitly will necessarily override this
 In this chapter we have seen the basics of writing our own uFFI call-outs. We declare an FFI binding to a C function by specifying the name of the function, its return type, its arguments, and the library the function belongs to. uFFI uses this information to load the library in memory, look up the function, demarshall our Pharo arguments to C types and push them, call the function, and marshall any C return values back into Pharo objects.
 
 [[[language=smalltalk
-FFITutorial class >> ticksSinceStart [
-	^ self ffiCall: #( uint clock () )
+FFITutorial class >> time [
+	^ self ffiCall: #( uint time ( NULL ) )
 ]
 ]]]
 

--- a/Chapters/1-callouts.pillar
+++ b/Chapters/1-callouts.pillar
@@ -1,284 +1,284 @@
-!! Foreign Function Interface and Call-Outs
+!! Foreign Function Interface and Call\-Outs
 
-A Foreign Function Interface (FFI) is a programming language mechanism that allows software written in one language to use resources (functions and data structures) that were written in and compiled with a different language.  These "foreign" resources typically take the form of shared libraries, such as DLL files in Windows (or '.so' files in Linux and Mac) and can include run-time services made available by your operating system.  A good example is a driver provided by a vendor of a computer peripheral, such as a printer or a network card.
+A Foreign Function Interface (FFI) is a programming language mechanism that allows software written in one language to use resources (functions and data structures) that were written in and compiled with a different language.  These \"foreign\" resources typically take the form of shared libraries, such as DLL files in Windows (or \'.so\' files in Linux and Mac) and can include run\-time services made available by your operating system.  A good example is a driver provided by a vendor of a computer peripheral, such as a printer or a network card.
 
-Code sharing and reuse via an FFI is fundamentally different from source code "includes", calls to IDE libraries, or messages sent to the base classes provided by your language's development environment.  In those cases, your compiler can link function calls and share structured data while making convenient assumptions about the object code interface (known as the ABI, or Application Binary Interface).  This is familiar programming: We follow published APIs (Application Programming Interfaces) as we write our code, and the compiler takes care of the low-level connections for us transparently.
+Code sharing and reuse via an FFI is fundamentally different from source code \"includes\", calls to IDE libraries, or messages sent to the base classes provided by your language\'s development environment.  In those cases, your compiler can link function calls and share structured data while making convenient assumptions about the object code interface (known as the ABI, or Application Binary Interface).  This is familiar programming\: We follow published APIs (Application Programming Interfaces) as we write our code, and the compiler takes care of the low\-level connections for us transparently.
 
-However, if the compiled resources we wish to link to were built with a different language (or even a different compiler of the same language), the bits and bytes may not line up properly when we push arguments, make calls, and retrieve results, due to the different standards that the other code's compiler followed when the borrowed code was produced.  In this case, more detailed bookkeeping must be followed by our language to make ABI translations and ensure that differences in issues such as data alignment, byte ordering, calling conventions, garbage collection, pointer references, and so forth are accounted for.  Without this, we risk not only getting incorrect results \-\- we could crash our process (or even the operating system).
+However, if the compiled resources we wish to link to were built with a different language (or even a different compiler of the same language), the bits and bytes may not line up properly when we push arguments, make calls, and retrieve results, due to the different standards that the other code\'s compiler followed when the borrowed code was produced.  In this case, more detailed bookkeeping must be followed by our language to make ABI translations and ensure that differences in issues such as data alignment, byte ordering, calling conventions, garbage collection, pointer references, and so forth are accounted for.  Without this, we risk not only getting incorrect results \-\- we could crash our process (or even the operating system).
 
-While in theory FFI interfaces can be defined to link any pair of differing languages, most languages are designed to interact with libraries written in the C language.  This is because C has a long heritage and widespread use, and (importantly) C has a predictable, standardized way to compile functions and structures.  So with Pharo also choosing C as an FFI target we gain two major advantages: first, by basing ourselves on such "standard" formats, we can build tools that simplify interoperability with an extensive array of existing C libraries.  Second, since nearly every other language is doing the same, we can simply join those mutual C-standard ABIs together to form a bridge between different systems \-\- allowing us to program at the source level of a C API.
+While in theory FFI interfaces can be defined to link any pair of differing languages, most languages are designed to interact with libraries written in the C language.  This is because C has a long heritage and widespread use, and (importantly) C has a predictable, standardized way to compile functions and structures.  So with Pharo also choosing C as an FFI target we gain two major advantages\: first, by basing ourselves on such \"standard\" formats, we can build tools that simplify interoperability with an extensive array of existing C libraries.  Second, since nearly every other language is doing the same, we can simply join those mutual C\-standard ABIs together to form a bridge between different systems \-\- allowing us to program at the source level of a C API.
 
-This booklet shows one such FFI definition for Pharo: the Unified FFI framework, or uFFI for short.
+This booklet shows one such FFI definition for Pharo\: the Unified FFI framework, or uFFI for short.
 
-The Pharo uFFI is an API framework that eases communication between Pharo code and code that follows a C-style interface, making it possible to easily interact with external C libraries.  Given that 'calling functions' is the ultimate objective of someone using an FFI, you will see that uFFI also helps with several other concerns, such as finding C function interfaces, transforming data between the Pharo world and the C world, accessing C structures, defining C-to-Pharo callbacks, and others.
+The Pharo uFFI is an API framework that eases communication between Pharo code and code that follows a C\-style interface, making it possible to easily interact with external C libraries.  Given that \'calling functions\' is the ultimate objective of someone using an FFI, you will see that uFFI also helps with several other concerns, such as finding C function interfaces, transforming data between the Pharo world and the C world, accessing C structures, defining C\-to\-Pharo callbacks, and others.
 
-Pharo uFFI has been developed by E. Lorenzano, and has received many contributions over the years from Pharo's open source community.
+Pharo uFFI has been developed by E. Lorenzano, and has received many contributions over the years from Pharo\'s open source community.
 
 !!! Calling a simple external function
 
 To illustrate the purpose and usage of uFFI, we will start with an example.
 Suppose we want to know the amount of time the image has been running by calling the underlying OS function
-named ==clock==. This function is part of the standard C library (==libc==). Its declaration in C is:
+named ==clock==. This function is part of the standard C library (==libc==). Its declaration in C is\:
 
 [[[
-clock_t clock( void );
+clock\_t clock( void )\;
 ]]]
 
-For the sake of simplicity, let's treat ==clock=='s return type as an unsigned ==uint== instead of ==clock\_t==.
+For the sake of simplicity, let\'s treat ==clock==\'s return type as an unsigned ==uint== instead of ==clock\_t==.
 (We will discuss types, conversions, and typedefs in subsequent chapters.)
-This results in the following C function declaration:
+This results in the following C function declaration\:
 
 [[[
 uint clock( void )
 ]]]
 
 To call ==clock== from Pharo using uFFI, we need to define a binding between a Pharo method and the ==clock== function.
-FFI bindings are classes and methods that provide an object-oriented means of accessing C libraries, implementing all the glue required to join the Pharo world and the C world.
+FFI bindings are classes and methods that provide an object\-oriented means of accessing C libraries, implementing all the glue required to join the Pharo world and the C world.
 
-To write our first binding, let's start by defining a new class, ==FFITutorial==.
+To write our first binding, let\'s start by defining a new class, ==FFITutorial==.
 This class will act as a module and encapsulate not only the functions we want to call but also any state we would like to persist.
-To access the ==clock== function, we then define a method in our ==FFITutorial== class using the ==ffiCall:module:== message to specify the declaration of the C function and indicate where it is defined. We will technically refer to this binding as a ''call-out'', since it ''calls'' a function in the ''outside'' world (the C world).
+To access the ==clock== function, we then define a method in our ==FFITutorial== class using the ==ffiCall\:module\:== message to specify the declaration of the C function and indicate where it is defined. We will technically refer to this binding as a ''call\-out'', since it ''calls'' a function in the ''outside'' world (the C world).
 
-If we are hosted on a Linux system, we define this class and method like so:
+If we are hosted on a Linux system, we define this class and (class\-side) method like so\:
 
-[[[language=smalltalk
-Object subclass: #FFITutorial
-	instanceVariableNames: ''
-	classVariableNames: ''
-	package: 'FFITutorial'
+[[[language\=smalltalk
+Object subclass\: \\#FFITutorial
+	instanceVariableNames\: \'\'
+	classVariableNames\: \'\'
+	package\: \'FFITutorial\'
 
 FFITutorial class >> ticksSinceStart [
-  ^ self ffiCall: #( uint clock () ) module: 'libc.so.6'
+  \^ self ffiCall\: \#( uint clock() ) module\: \'libc.so.6\'
 ]
 ]]]
 
-where =='libc.so.6'== refers to the current version of the C shared library on our host system.  (We can find out which version we have by entering ==ls -1 /lib/*/libc.so*== in a Linux terminal window.)
+where we have simply copied the C declaration into a Pharo Array literal, then added ==\'libc.so.6\'== as a reference to the current version of its C shared library on our Linux host system.  (We can find out which version we have by entering ==ls \-1 /lib/\*/libc.so\*== in a Linux terminal window.)
 
-To define the same binding for other platforms, we need to replace the =='libc.so.6'== string by e.g., =='libc.dylib'== if we're running on MacOS, or =='msvcrt.dll'== if we use Windows. The equivalent definitions for MacOS and Windows are then:
+To define the same binding for other host platforms, we need to replace the ==\'libc.so.6\'== string by e.g., ==\'libc.dylib\'== if we\'re running on MacOS, or ==\'msvcrt.dll\'== if we use Windows. The equivalent definitions for MacOS and Windows are then\:
 
-[[[language=smalltalk
+[[[language\=smalltalk
 FFITutorial class >> ticksSinceStart [
-  ^ self ffiCall: #( uint clock () ) module: 'libc.dylib'
+  \^ self ffiCall\: \#( uint clock() ) module\: \'libc.dylib\'
 ]
 ]]]
 
 and
 
-[[[language=smalltalk
+[[[language\=smalltalk
 FFITutorial class >> ticksSinceStart [
-  ^ self ffiCall: #( uint clock () ) module: 'msvcrt.dll'
+  \^ self ffiCall\: \#( uint clock() ) module\: \'msvcrt.dll\'
 ]
 ]]]
 
-Finally, we can use our freshly-created bindings in a Pharo playground by inspecting or printing the following expression:
+Finally, we can use our freshly\-created bindings in a Pharo playground by inspecting or printing the following expression\:
 
-[[[language=smalltalk
+[[[language\=smalltalk
 FFITutorial ticksSinceStart
 ]]]
 
 If everything works as expected, this expression will return the number of native clock ticks since our Pharo process was launched.
 
-!!! Analyzing the FFI Call-Out
+!!! Analyzing the FFI Call\-Out
 @OriginalTicksSinceStartBinding
 
 The simple example we ran in the previous section illustrates several important uFFI concepts.
-For starters, let's look at the binding definition again:
+For starters, let\'s look at the binding definition again\:
 
-[[[language=smalltalk
+[[[language\=smalltalk
 FFITutorial class >> ticksSinceStart [
-	^ self ffiCall: #( uint clock () ) module: 'libc.so.6'
+	\^ self ffiCall\: \#( uint clock() ) module\: \'libc.so.6\'
 ]
 ]]]
 
-This call-out binding, a Pharo method, is called ==ticksSinceStart== and happens to be named differently than the C function we are calling.
-Indeed, uFFI does not impose any restrictions as far as how to call your external functions.  This can come in handy for decoupling your methods from underlying C-level implementation details.
+This call\-out binding, a Pharo method, is called ==ticksSinceStart== and happens to be named differently than the C function we are calling.
+Indeed, uFFI does not impose any restrictions as far as how to call your external functions.  This can come in handy for decoupling your methods from underlying C\-level implementation details.
 
-We invoke the C function using the Pharo method ==ffiCall:module:==, which is defined by uFFI.  We assemble the message arguments it needs by deconstructing the target C function declaration and referencing the name of the library in which it's defined.  uFFI takes the pieces and performs all the necessary work to make the call-out.  Continuing our example, we see that uFFI:
-- Searches for the specified library in our host system,
+We invoke the C function using the Pharo method ==ffiCall\:module\:==, which is defined by uFFI.  We provide the message arguments it needs usually by just copying and pasting the target C function declaration inside a Pharo Array literal, then referencing the name of the library in which it\'s defined.  uFFI interprets the declaration and performs all the necessary work needed to make the call\-out and return the result\:
+- uFFI searches for the specified library in our host system,
 - On finding it, loads the C library into memory,
 - Indexes the specified function within the library,
 - Transforms and pushes our Pharo arguments (if any) onto the stack,
 - Performs the call to the C function,
 - And finally transforms the return value into a Pharo object.
 
-We said above that we need to "deconstruct" the C function declaration in order to create the first argument in our ==ffiCall:module:== message.  This argument is a Pharo Array of String, where each string element is a piece of the C declaration; we simply list the pieces in the same sequence as the C declaration.  The uFFI makes sense of it, and dynamically creates a C call with this information.
-
-This is best understood by example, so, to continue with our previous, we render our C declaration in Pharo as a literal string array, like so:
+To form the first argument in our example, we render our C declaration for ==clock== in Pharo as a literal string array, like so\:
 
 [[[
-#( uint clock () )
+\#( uint clock() )
 ]]]
 
-The first element of our array is ==uint==, which is the function return ''type''.  This is followed by the function name, ==clock==.  Following the function name \-\-and note the space!\-\- we embed another Pharo Array to list the formal arguments the C function expects, in order. In this case, ==clock== takes no arguments, so we must provide an empty Array.
+The first element of our array is ==uint==, which is the function return ''type''.  This is followed by the function name, ==clock==.  Following the function name, we embed another Pharo Array to list the formal arguments the C function expects, in order. In this case, ==clock== takes no arguments, so we must provide an empty Array.
 
-Another way to think of it is this: If we look past the outer ==#()== Pharo syntax, what we see inside is our C function prototype, appearing very similar to normal C syntax (but with spaces in unusual places).  uFFI was intentionally defined this way so that in most cases we can simply copy-paste a C function declaration taken from a header file or documentation, add some required spaces, wrap it in ==#()==, and it's ready for use.
+Another way to think of the declaration argument is this\: If we look past the outer ==\#( )== wrapper, what we see inside is our C function prototype, appearing very similar to normal C syntax.  This is possible due to the coincidental nature of Smalltalk syntax\: our use of strings and array notation in Pharo nicely mirrors how we write a C function declaration.  uFFI was intentionally designed to take advantage of this so that in most cases we can simply copy\-paste a C function declaration taken from a header file or documentation, wrap it in ==\#( )==, and it\'s ready for use\!
 
-Our ==ffiCall:module:== message also takes a second argument (=='libc.so.6'== in our Linux example), which is the name of the library that contains the function.  In many cases we do not need to provide a full path to the file in our host system.  However, it should already be apparent that our bindings can be platform dependent, if the library we need is also platform-dependent.  We will explore how to define bindings in a platform-independent way in a following section.
+Our ==ffiCall\:module\:== message also needs a second argument (==\'libc.so.6\'== in our Linux example), which is the name of the library in our host that contains the function.  In many cases we do not need to provide a full path to the file in our host system.  However, it should already be apparent that our bindings can be platform dependent if the library we need is also platform\-dependent.  We will explore how to define bindings in a platform\-independent way in a following section.
 
 
 !!! Notes on Value Marshalling
 
-To fully understand the previous example, we still need to explain how the C ==uint== return value (a non-object; a cluster of bytes popped off the stack) gets transformed into a Pharo ==SmallInteger== ''object''.  Remember, C does not understand objects and does not do us the favor of returning values as attributes embedded within an object; we must somehow create an appropriate type of Pharo object, then migrate the C return value to become ''its'' value.  Our code then receives this Pharo object.
+To fully understand the previous example, we still need to explain how the C ==uint== return value (a non\-object\; a cluster of bytes popped off the stack) gets transformed into a Pharo ==SmallInteger== ''object''.  Remember, C does not understand objects and does not do us the favor of returning values as attributes encapsulated within an object.  We must somehow create an appropriate type of Pharo object, then migrate the C return value to become ''its'' value.  Our code then receives this Pharo object.
 
-This process of converting values between different internal representations is called ''marshalling'', and in most cases is managed automatically in Pharo by uFFI.  For example, uFFI internally maps these standard C values to Smalltalk objects:
-- Types ==int==, ==uint==, ==long==, ==ulong== are mapped to Pharo integers (small or long integers, depending on the platform architecture).
-- Types ==float== and ==double== are mapped to Pharo floats.
+This process of converting values between different internal representations is called ''marshalling'', and in most cases is managed automatically in Pharo by uFFI.  For example, uFFI internally maps the following standard C values to Smalltalk objects\:
+- Types ==int==, ==uint==, ==long==, ==ulong== are marshalled into Pharo integers (small or long integers, depending on the platform architecture).
+- Types ==float== and ==double== are marshalled into Pharo floats.
 
-Correct marshalling (and ''demarshalling'') of values is therefore crucial for correct behavior of the bindings, particularly because the C language is so closely tied to underlying machine architecture. And yet, C values are merely "naked" bits and bytes in registers and memory; they therefore have no inherent context or meaning.  Consequently, they can be interpreted in many different ways, including by the Pharo run-time engine.  The correct interpretation, involving such issues as byte ordering, type size, alignment requirements, string length/termination, etc. must be knowable, known, and properly handled.  An object can tell you what it is, but a string of bits is just a string of bits...
+Correct marshalling (and ''demarshalling'') of values is therefore crucial for correct behavior of the bindings, particularly because the C language is so closely tied to underlying machine architecture. And yet, C values are merely \"naked\" bits and bytes in registers and memory\; they have no inherent context or meaning.  Consequently, they can be interpreted in many different ways, including by the Pharo run\-time engine.  The correct interpretation, involving such issues as byte ordering, type size, alignment requirements, string length/termination, etc. must be knowable, known, and properly handled.  An object can tell you what it is, but a string of bits is just a string of bits...
 
-As an example, consider the C integer value 0x00000000 (four contiguous '0x00' bytes).  This can be interpreted as the small integer 0, as the ''false'' object, or as a null pointer \-\- all depending on the marshalling rule selected for the inferred type.  This means that the developer coding the binding method needs to ''carefully'' and ''correctly'' describe the types of argument bindings so uFFI will then correctly interpret and transform those values.  This is programming at the ABI level (binary representations), so precision counts!  You are working side-by-side with the compiler, and inattention to detail can lead to crashes (or strange behavior that can be difficult to diagnose).
+As an example, consider the C integer value 0x00000000 (four contiguous \'0x00\' bytes).  This can be interpreted as the small integer zero, as the ''false'' object, or as a null pointer \-\- all depending on the marshalling rule selected for the inferred type.  This means that the developer coding the binding method needs to ''carefully'' and ''correctly'' describe the types of argument bindings so uFFI will then correctly interpret and transform those values.  This is programming at the ABI level (binary representations), so precision counts\!  You are working side\-by\-side with the compiler, and inattention to detail can lead to crashes (or strange behavior that can be difficult to diagnose).
 
 In the following chapters we will explore the marshalling rules more in detail and see how they apply not only for return values but also for arguments.
-Moreover, we will learn how to define our own user-defined data types and type mappings, allowing us to customize and fine-tune the marshalling rules to fit our particular needs.
+Moreover, we will learn how to define our own user\-defined data types and type mappings, allowing us to customize and fine\-tune the marshalling rules to fit our particular needs.
 
 !!! Libraries
 
-We saw earlier that a call-out binding requires us to specify a module or library that uFFI uses to locate and load the desired function.  In our previous example, we indicated to Pharo that the ==clock== function we need was inside the standard C library, namely, the file ==libc.so.6==; however, this form of the library exists on Linux systems, but not Windows.
+We saw earlier that a call\-out binding requires us to specify a module or library that uFFI uses to locate and load the desired function.  In our previous example, we indicated to Pharo that the ==clock== function we need was inside the standard C library, namely, the file ==libc.so.6==.  However, this form of the library exists in Linux systems, but not in Windows.
 
-So we could say that this solution is not portable enough: One of the hallmark qualities of Smalltalk is supposed to be platform independence.  But if we want to load and run ''this'' code on a different host platform, we are faced with changing the library name to match the name on our new host system.  Worse, the libraries we need will not necessarily have the same name, or be located in the same place on all platforms. (And very likely will not.  Not only that, we need to be sure we catch every instance of these kinds of dependencies when we peform this 'migration'. Ugh!)
+So we could say that this solution is not portable enough\: One of the hallmark qualities of Smalltalk is supposed to be platform independence.  But if we want to load and run ''this'' code on a different host platform, we are faced with changing the library name to match the name on our new host system.  Worse, the libraries we need will all too often not have the same name, or be located in the same place on all platforms. Not only that, we would need to be sure we catch every instance of these kinds of dependencies when we perform this \"migration\". Ugh\!
 
-One way to overcome this issue would be to define a set of bindings, one per platform, and decide which one to call based on detecting the platform at run-time, as follows:
+One way to overcome this issue would be to define a set of bindings, one per platform, and decide which one to call based on which platform we detect at run\-time, as follows\:
 
-[[[language=smalltalk
+[[[language\=smalltalk
 FFITutorial class >> ticksSinceStart [
   self platform isWindows
-    ifTrue: [ ^ self ticksSinceStartWindows ].
+    ifTrue\: [ \^ self ticksSinceStartWindows ].
   self platform isUnix
-    ifTrue: [ ^ self ticksSinceStartUnix ].
+    ifTrue\: [ \^ self ticksSinceStartUnix ].
   self platform isOSX
-    ifTrue: [ ^ self ticksSinceStartOSX ].
-  self error: 'Non-supported platform'
+    ifTrue\: [ \^ self ticksSinceStartOSX ].
+  self error\: \'Non\-supported platform\'
 ]
 
 FFITutorial class >> ticksSinceStartUnix [
-  ^ self ffiCall: #( uint clock () ) module: 'libc.so.6'
+  \^ self ffiCall\: \#( uint clock() ) module\: \'libc.so.6\'
 ]
 
 FFITutorial class >> ticksSinceStartOSX [
-  ^ self ffiCall: #( uint clock () ) module: 'libc.dylib'
+  \^ self ffiCall\: \#( uint clock() ) module\: \'libc.dylib\'
 ]
 
 FFITutorial class >> ticksSinceStartWindows [
-  ^ self ffiCall: #( uint clock () ) module: 'msvcrt.dll'
+  \^ self ffiCall\: \#( uint clock() ) module\: \'msvcrt.dll\'
 ]
 ]]]
 
-But this means the binding code (essentially the same in all cases) gets repeated three times, and any changes to the binding design will require changing all three binding methods. This may look simple enough for our ==clock== binding, but repeating the code of complex bindings is likely not an optimal solution...
+But this solution means our binding code (which is essentially the same in all cases) gets repeated three times, and any changes to the binding design will require changing all three binding methods. This may look simple enough for our ==clock== binding, but repeating the code of complex bindings is likely not an optimal solution...
 
-uFFI solves this problem by allowing us to use ''library objects'' instead of plain strings like we did earlier.  A library object represents a library as an instance of ==FFILibrary==, abstracting away any platform dependencies.  This library class defines methods ==macModuleName==, ==unixModuleName==, and ==win32ModuleName==; uFFI internally selects the correct library name at run-time after sensing the host platform. Bonus: The selection process can now be as complex as dynamically searching in different directories on your host system for the correct version of a library, as we will see later on.
+uFFI solves this problem by allowing us to use ''library objects'' instead of plain strings like we did earlier.  A library object represents a library as an instance of ==FFILibrary==, abstracting away any platform dependencies.  This library class defines methods ==macModuleName==, ==unixModuleName==, and ==win32ModuleName==\; uFFI internally selects the correct library name at run\-time after sensing the host platform. Bonus\: This selection is a ''process'', not a literal (a string), so it can now include the ability to dynamically search through different directories on your host system to locate the correct version of a library, as we will see shortly.
 
-So for our example, we can define a library, ==MyLibC==, as follows:
+So for our example, we can now define such a library, ==MyLibC==, as follows (being careful to note that the methods are ''instance side'' overrides)\:
 
-[[[language=smalltalk
-FFILibrary subclass: #MyLibC
-	instanceVariableNames: ''
-	classVariableNames: ''
-	package: 'UnifiedFFI-Libraries'
+[[[language\=smalltalk
+FFILibrary subclass\: \#MyLibC
+	instanceVariableNames\: \'\'
+	classVariableNames\: \'\'
+	package\: \'UnifiedFFI\-Libraries\'
 
 MyLibC >> macModuleName [
-	^ 'libc.dylib'
+	\^ \'libc.dylib\'
 ]
 
 MyLibC >> unixModuleName [
-	^ 'libc.so.6'
+	\^ \'libc.so.6\'
 ]
 
 MyLibC >> win32ModuleName [
-	"While this is not a proper 'libc', MSVCRT has the functions we need here."
-	^ 'msvcrt.dll'
+	"While this is not a proper \'libc\', MSVCRT has the functions we need here."
+	\^ \'msvcrt.dll\'
 ]
 ]]]
 
-To use this improved technique, we modify our ''original'' binding method (in *@OriginalTicksSinceStartBinding*) to substitute our library in place of the library name string:
+To use this improved technique, we modify our ''original'' binding method (in *@OriginalTicksSinceStartBinding*) to substitute our library object (as a class) in place of the library name string\:
 
-[[[language=smalltalk
+[[[language\=smalltalk
 FFITutorial class >> ticksSinceStart [
-	^ self ffiCall: #( uint clock () ) module: MyLibC
+	\^ self ffiCall\: \#( uint clock() ) module\: MyLibC
 ]
 ]]]
 
-''This'' version will run on all three platform types, ''and'' do so without us having to repeat the same code three times.
+''This'' version will run on all three platform types, ''and'' do so without us having to repeat the same code multiple times.
 
 !!! Library Searching
 
-The ==macModuleName==, ==unixModuleName==, and ==win32ModuleName== methods allow us, as developers, to employ different strategies to search for libraries and functions, depending on our host platform. If these methods return a relative path, library searching starts in common/default library directories on the system, or adjacent to the virtual machine executable. If they return an absolute path, default system locations will not be searched, only the specified path. In either case, if the library is not found or cannot be loaded, an exception is raised.
+The ==macModuleName==, ==unixModuleName==, and ==win32ModuleName== methods allow us, as developers, to employ different strategies to search for libraries and functions, depending on our host platform. If these methods return a relative path, library searching starts in common/default library directories on the system, or adjacent to the virtual machine executable. If they return an absolute path, default system locations will not be searched, only the specified path will be. In either case, if the library is not found or cannot be loaded, an exception is raised.
 
-For example, an alternative override definition for ==unixModuleName== can limit the search for 'libc' to load only from the ==/usr/lib/== directory on the host:
+For example, an alternative override for ==unixModuleName== can limit the search for ==libc== to load only from the ==/usr/lib/== directory on the host\:
 
 [[[
 MyLibC >> unixModuleName [
-	^ '/usr/bin/libc.so.6'
+	\^ \'/usr/bin/libc.so.6\'
 ]
 ]]]
 
 Moreover, we are not constrained to simply return a string containing a path. The use of a method allows us to define and follow complex search rules, potentially locating needed libraries dynamically.
 
-To take a real-world example, let's consider where the Cairo graphics library installs its resources on Unix-type systems. Although they are generally compatible, different '*nix' distros have evolved in ways that occasionally led to divergence in their file system structure, the placement of operating system files, and where they prefer to install packages the user may add.  This is especially true (for historical reasons) where structure was added to avoid mixing 32-bit and 64-bit libraries.  (Unix pre-dates the 8-bit micro-computer age.  It may be older than you are!)
+To take a real\-world example, let\'s consider where the Cairo graphics library installs its resources on Unix\-type systems. Although they are generally compatible, different \"\*nix\" distros have evolved in ways that occasionally led to divergence in their file system structure, the placement of operating system files, and where they prefer to install packages the user may add.  This is especially true (for historical reasons) where structure was added to avoid mixing 32\-bit and 64\-bit libraries.  (Unix pre\-dates the 8\-bit micro\-computer age.  It may be older than you are\!)
 
-In the example below, the Cairo library search method for Unix checks for the existence of the library in ==/usr/lib/i386-linux-gnu==, ==/usr/lib32==, and ==/usr/lib==, and if found, returns the absolute path to that file.
+In the example below, the Cairo library search method for Linux checks for the existence of the library in each of ==/usr/lib/i386\-linux\-gnu==, ==/usr/lib32==, and ==/usr/lib==, and if found, returns the absolute path to that file\:
 
-[[[language=smalltalk
+[[[language\=smalltalk
 CairoLibrary >> unixModuleName [
-		"On different flavors of Linux, the path to the library may differ, depending on the distro and whether the system is 32- or 64-bit."
+		"On different flavors of Linux, the path to the library may differ, depending on the distro and whether the system is 32\- or 64\-bit."
 
-		#(
-			'/usr/lib/i386-linux-gnu/libcairo.so.2'
-			'/usr/lib32/libcairo.so.2'
-			'/usr/lib/libcairo.so.2')
-		do: [ :path |
-			path asFileReference exists ifTrue: [ ^ path ] ].
+		\#(
+			\'/usr/lib/i386\-linux\-gnu/libcairo.so.2\'
+			\'/usr/lib32/libcairo.so.2\'
+			\'/usr/lib/libcairo.so.2\')
+		do\: [ \:path \|
+			path asFileReference exists ifTrue\: [ \^ path ] ].
 
-		self error: 'Cannot locate Cairo library. Please check if it is installed on your system.'
+		self error\: \'Cannot locate Cairo library. Please check that it is installed on your system.\'
 ]
 ]]]
 
 !!! Sharing Libraries Between Bindings
 
-To finish this chapter, let's define a new binding to another function in the same library: ==time==.
+To finish this chapter, let\'s define a new binding to another function in the same C library\: ==time==.
 The ==time== function receives a (potentially null) C pointer and returns the current calendar time (as seconds of epoch), which we will once again assume is a ==uint== for simplicity.
 
 We can define our new binding as follows, providing a ==NULL== pointer as the function argument.
 (We leave it to the reader to look up the definition of the C function and determine the purpose of this argument.)
 
-[[[language=smalltalk
+[[[language\=smalltalk
 FFITutorial class >> time [
-	^ self ffiCall: #( uint time ( NULL ) ) module: MyLibC
+	\^ self ffiCall\: \#( uint time( NULL ) ) module\: MyLibC
 ]
 ]]]
 
-Our new binding references the ==MyLibC== library we defined earlier, so the above structure couples that code to both our bindings. To avoid such undesirable coupling, we can choose to refactor the class reference into a single method in our ==FFITutorial== class that can be used instead in both bindings.  To continue our example,
+Our new binding references the ==MyLibC== library we defined earlier, so the above structure couples that code to both our bindings. To avoid such undesirable coupling, we can choose to refactor the class reference into a single class method in our ==FFITutorial== class that can be used instead in both bindings.
 
-[[[language=smalltalk
+To continue our example,
+
+[[[language\=smalltalk
 FFITutorial class >> myLibrary [
-  ^ MyLibC
+  \^ MyLibC
 ]
 
 FFITutorial class >> ticksSinceStart [
-	^ self ffiCall: #( uint clock () ) module: self myLibrary
+	\^ self ffiCall\: \#( uint clock() ) module\: self myLibrary
 ]
 
 FFITutorial class >> time [
-	^ self ffiCall: #( uint time ( NULL ) ) module: self myLibrary
+	\^ self ffiCall\: \#( uint time( NULL ) ) module\: self myLibrary
 ]
 ]]]
 
-This strategy, however, is still not as neat as we would like it to be. Further refactoring could clean this up, but fortunately for us, uFFI already provides support for sharing library definitions between bindings.
+This strategy, however, is still not as neat as we would like it to be. Further refactoring could clean this up, but fortunately for us, uFFI provides the support we need for sharing library definitions between bindings.
 
-Any class defining a binding also has the option of defining a default library by overriding the ==ffiModuleName== method. Doing so allows us to omit a library definition altogether in our call-out bindings. The library will be automatically referenced by uFFI via the default method definition.
+Any class defining a binding also has the option of defining a default library by overriding the ==ffiLibraryName== class method. Doing so allows us to omit a library definition altogether in our call\-out bindings. The library will be automatically referenced by uFFI via the default method definition.
 
-Let's see how this further simplies things for us:
+Let\'s see how this further simplies things for us\:
 
-[[[language=smalltalk
-FFITutorial class >> ffiModuleName [
-  ^ MyLibC
+[[[language\=smalltalk
+FFITutorial class >> ffiLibraryName [
+  \^ MyLibC
 ]
 
 FFITutorial class >> ticksSinceStart [
-	^ self ffiCall: #( uint clock () )
+	\^ self ffiCall\: \#( uint clock() )
 ]
 
 FFITutorial class >> time [
-	^ self ffiCall: #( uint time ( NULL ) )
+	\^ self ffiCall\: \#( uint time( NULL ) )
 ]
 ]]]
 
@@ -286,16 +286,16 @@ Of course, bindings defining a library explicitly will necessarily override this
 
 !!! Conclusion
 
-In this chapter we have seen the basics of writing our own uFFI call-outs. We declare an FFI binding to a C function by specifying the name of the function, its return type, its arguments, and the library the function belongs to. uFFI uses this information to load the library in memory, look up the function, demarshall our Pharo arguments to C types and push them, call the function, and marshall any C return values back into Pharo objects.
+In this chapter we have seen the basics of writing our own uFFI call\-outs. We declare an FFI binding to a C function by specifying the name of the function, its return type, its arguments, and the library the function belongs to. uFFI uses this information to load the library in memory, look up the function, demarshall our Pharo arguments to C types and push them, call the function, and marshall any C return values back into Pharo objects.
 
-[[[language=smalltalk
+[[[language\=smalltalk
 FFITutorial class >> time [
-	^ self ffiCall: #( uint time ( NULL ) )
+	\^ self ffiCall\: \#( uint time( NULL ) )
 ]
 ]]]
 
 Since different platforms work differently, uFFI provides extensions to define a library as an object.
-Library objects define per-platform strategies to search for C libraries in the host file system. By specifying relative paths we let uFFI search for the library in a platform's standard locations, while absolute paths override such behavior. In addition, this mechanism allows developers to write bindings that can dynamically search for their libraries in multiple locations.
+Library objects define per\-platform strategies to search for C libraries in the host file system. By specifying relative paths we let uFFI search for the library in a platform\'s standard locations, while absolute paths override such behavior. In addition, this mechanism allows developers to write bindings that can dynamically search for their libraries in multiple locations.
 
 The next chapter covers function arguments of various types.  Although we glossed over its details on purpose, the ==time== binding described in the previous section has a literal ==NULL== pointer argument.
 We will see how literal arguments, which may be of different flavors, are very convenient syntactic sugar for specifying default argument values.


### PR DESCRIPTION
Outstanding issues: 
* Opening ' & " are not rendered correctly.  (The _DistributingPillar_ PDF didn't have anything on this one.  Is this just a peculiarity of the typeface style we're using?)
* I can't tell if I'm using the Pillar anchor syntax correctly.  (The guide needs examples, and the _Language-Pillar_ package for Atom won't render markup, so I can't preview it.)
* Still not sure what the team wants as far as showing tonel [  ] delimiters in code blocks...