### PR TITLE
Copy-edits for uFFI Booklet Chapter 2

### DIFF
--- a/Chapters/1-callouts.pillar
+++ b/Chapters/1-callouts.pillar
@@ -1,10 +1,10 @@
 !! Foreign Function Interface and Call\-Outs
 
-A Foreign Function Interface (FFI) is a programming language mechanism that allows software written in one language to use resources (functions and data structures) that were written in and compiled with a different language.  These \"foreign\" resources typically take the form of shared libraries, such as DLL files in Windows (or \'.so\' files in Linux and Mac) and can include run\-time services made available by your operating system.  A good example is a driver provided by a vendor of a computer peripheral, such as a printer or a network card.
+A Foreign Function Interface (FFI) is a programming language mechanism that allows software written in one language to use resources (functions and data structures) that were written in and compiled with a different language.  These \"foreign\" resources typically take the form of shared libraries, such as DLL files in Windows (or \'.so\' files in Linux and Mac) and can include run\-time services made available by your operating system.  A good example is a driver library provided by a vendor of a computer peripheral, such as a printer or a network card.
 
 Code sharing and reuse via an FFI is fundamentally different from source code \"includes\", calls to IDE libraries, or messages sent to the base classes provided by your language\'s development environment.  In those cases, your compiler can link function calls and share structured data while making convenient assumptions about the object code interface (known as the ABI, or Application Binary Interface).  This is familiar programming\: We follow published APIs (Application Programming Interfaces) as we write our code, and the compiler takes care of the low\-level connections for us transparently.
 
-However, if the compiled resources we wish to link to were built with a different language (or even a different compiler of the same language), the bits and bytes may not line up properly when we push arguments, make calls, and retrieve results, due to the different standards that the other code\'s compiler followed when the borrowed code was produced.  In this case, more detailed bookkeeping must be followed by our language to make ABI translations and ensure that differences in issues such as data alignment, byte ordering, calling conventions, garbage collection, pointer references, and so forth are accounted for.  Without this, we risk not only getting incorrect results \-\- we could crash our process (or even the operating system).
+However, if the compiled resources we wish to link to were built with a different language (or even a different compiler of the same language), the bits and bytes may not line up properly when we push arguments, make calls, and retrieve results, due to the different standards that the other code\'s compiler followed when the borrowed code was produced.  In this case, more detailed bookkeeping must be followed by our language to make ABI translations and ensure that differences in issues such as data alignment, byte ordering, calling conventions, garbage collection, pointer references, and so forth are all accounted for.  Without this, we risk not only getting incorrect results \-\- we could crash our process (or even the operating system).
 
 While in theory FFI interfaces can be defined to link any pair of differing languages, most languages are designed to interact with libraries written in the C language.  This is because C has a long heritage and widespread use, and (importantly) C has a predictable, standardized way to compile functions and structures.  So with Pharo also choosing C as an FFI target we gain two major advantages\: first, by basing ourselves on such \"standard\" formats, we can build tools that simplify interoperability with an extensive array of existing C libraries.  Second, since nearly every other language is doing the same, we can simply join those mutual C\-standard ABIs together to form a bridge between different systems \-\- allowing us to program at the source level of a C API.
 
@@ -24,12 +24,12 @@ named ==clock==. This function is part of the standard C library (==libc==). Its
 clock\_t clock( void )\;
 ]]]
 
-For the sake of simplicity, let\'s treat ==clock==\'s return type as an unsigned ==uint== instead of ==clock\_t==.
+For the sake of simplicity, let\'s treat ==clock==\'s return type as an unsigned, ==uint==, instead of ==clock\_t==.
 (We will discuss types, conversions, and typedefs in subsequent chapters.)
 This results in the following C function declaration\:
 
 [[[
-uint clock( void )
+uint clock( void )\;
 ]]]
 
 To call ==clock== from Pharo using uFFI, we need to define a binding between a Pharo method and the ==clock== function.
@@ -39,10 +39,10 @@ To write our first binding, let\'s start by defining a new class, ==FFITutorial=
 This class will act as a module and encapsulate not only the functions we want to call but also any state we would like to persist.
 To access the ==clock== function, we then define a method in our ==FFITutorial== class using the ==ffiCall\:module\:== message to specify the declaration of the C function and indicate where it is defined. We will technically refer to this binding as a ''call\-out'', since it ''calls'' a function in the ''outside'' world (the C world).
 
-If we are hosted on a Linux system, we define this class and (class\-side) method like so\:
+If our Pharo code is hosted on a Linux system, we define this class and (class\-side) method like so\:
 
 [[[language\=smalltalk
-Object subclass\: \\#FFITutorial
+Object subclass\: \#FFITutorial
 	instanceVariableNames\: \'\'
 	classVariableNames\: \'\'
 	package\: \'FFITutorial\'
@@ -93,11 +93,13 @@ FFITutorial class >> ticksSinceStart [
 This call\-out binding, a Pharo method, is called ==ticksSinceStart== and happens to be named differently than the C function we are calling.
 Indeed, uFFI does not impose any restrictions as far as how to call your external functions.  This can come in handy for decoupling your methods from underlying C\-level implementation details.
 
-We invoke the C function using the Pharo method ==ffiCall\:module\:==, which is defined by uFFI.  We provide the message arguments it needs usually by just copying and pasting the target C function declaration inside a Pharo Array literal, then referencing the name of the library in which it\'s defined.  uFFI interprets the declaration and performs all the necessary work needed to make the call\-out and return the result\:
-- uFFI searches for the specified library in our host system,
+We invoke the C function using the Pharo method ==ffiCall\:module\:==, which is defined by uFFI.  We provide the message arguments it needs usually by just copying and pasting the target C function declaration inside a Pharo Array literal, then referencing the name of the library in which it\'s defined (which is general will be platform\-dependent).
+
+uFFI interprets the declaration and performs all the necessary work needed to make the call\-out and return the result.  In general,
+- uFFI searches for the specified library in the host system,
 - On finding it, loads the C library into memory,
 - Indexes the specified function within the library,
-- Transforms and pushes our Pharo arguments (if any) onto the stack,
+- Transforms and pushes Pharo arguments (if any) onto the stack,
 - Performs the call to the C function,
 - And finally transforms the return value into a Pharo object.
 
@@ -112,7 +114,6 @@ The first element of our array is ==uint==, which is the function return ''type'
 Another way to think of the declaration argument is this\: If we look past the outer ==\#( )== wrapper, what we see inside is our C function prototype, appearing very similar to normal C syntax.  This is possible due to the coincidental nature of Smalltalk syntax\: our use of strings and array notation in Pharo nicely mirrors how we write a C function declaration.  uFFI was intentionally designed to take advantage of this so that in most cases we can simply copy\-paste a C function declaration taken from a header file or documentation, wrap it in ==\#( )==, and it\'s ready for use\!
 
 Our ==ffiCall\:module\:== message also needs a second argument (==\'libc.so.6\'== in our Linux example), which is the name of the library in our host that contains the function.  In many cases we do not need to provide a full path to the file in our host system.  However, it should already be apparent that our bindings can be platform dependent if the library we need is also platform\-dependent.  We will explore how to define bindings in a platform\-independent way in a following section.
-
 
 !!! Notes on Value Marshalling
 
@@ -133,7 +134,7 @@ Moreover, we will learn how to define our own user\-defined data types and type 
 
 We saw earlier that a call\-out binding requires us to specify a module or library that uFFI uses to locate and load the desired function.  In our previous example, we indicated to Pharo that the ==clock== function we need was inside the standard C library, namely, the file ==libc.so.6==.  However, this form of the library exists in Linux systems, but not in Windows.
 
-So we could say that this solution is not portable enough\: One of the hallmark qualities of Smalltalk is supposed to be platform independence.  But if we want to load and run ''this'' code on a different host platform, we are faced with changing the library name to match the name on our new host system.  Worse, the libraries we need will all too often not have the same name, or be located in the same place on all platforms. Not only that, we would need to be sure we catch every instance of these kinds of dependencies when we perform this \"migration\". Ugh\!
+So we could say that this solution is not portable enough\: One of the hallmark qualities of Smalltalk is supposed to be platform independence.  But if we want to load and run ''this'' code on a different host platform, we are faced with changing the library name to match the name on our new host system.  Worse, the libraries we need will all too often not have the same name, nor be located in the same place on all platforms. Not only that, we would need to be sure we catch every instance of these kinds of dependencies when we perform this \"migration\". Ugh\!
 
 One way to overcome this issue would be to define a set of bindings, one per platform, and decide which one to call based on which platform we detect at run\-time, as follows\:
 
@@ -163,7 +164,7 @@ FFITutorial class >> ticksSinceStartWindows [
 
 But this solution means our binding code (which is essentially the same in all cases) gets repeated three times, and any changes to the binding design will require changing all three binding methods. This may look simple enough for our ==clock== binding, but repeating the code of complex bindings is likely not an optimal solution...
 
-uFFI solves this problem by allowing us to use ''library objects'' instead of plain strings like we did earlier.  A library object represents a library as an instance of ==FFILibrary==, abstracting away any platform dependencies.  This library class defines methods ==macModuleName==, ==unixModuleName==, and ==win32ModuleName==\; uFFI internally selects the correct library name at run\-time after sensing the host platform. Bonus\: This selection is a ''process'', not a literal (a string), so it can now include the ability to dynamically search through different directories on your host system to locate the correct version of a library, as we will see shortly.
+uFFI solves this problem by allowing us to use ''library objects'' instead of plain strings like we did earlier.  A library object represents a library as an instance of ==FFILibrary==, abstracting away any platform dependencies.  This library class defines methods ==macModuleName==, ==unixModuleName==, and ==win32ModuleName==\; uFFI internally selects the correct library name at run\-time after sensing the host platform. Bonus\: This selection is a ''process'', not a literal (a string), so it can now include behavior, such as the ability to dynamically search through different directories on your host system to locate the correct version of a library, as we will see shortly.
 
 So for our example, we can now define such a library, ==MyLibC==, as follows (being careful to note that the methods are ''instance side'' overrides)\:
 
@@ -201,7 +202,7 @@ FFITutorial class >> ticksSinceStart [
 
 The ==macModuleName==, ==unixModuleName==, and ==win32ModuleName== methods allow us, as developers, to employ different strategies to search for libraries and functions, depending on our host platform. If these methods return a relative path, library searching starts in common/default library directories on the system, or adjacent to the virtual machine executable. If they return an absolute path, default system locations will not be searched, only the specified path will be. In either case, if the library is not found or cannot be loaded, an exception is raised.
 
-For example, an alternative override for ==unixModuleName== can limit the search for ==libc== to load only from the ==/usr/lib/== directory on the host\:
+For example, an alternative override for ==unixModuleName== can limit the search for ==libc== to load only from the ==/usr/lib/== directory on the host this way\:
 
 [[[
 MyLibC >> unixModuleName [

--- a/Chapters/1-callouts.pillar
+++ b/Chapters/1-callouts.pillar
@@ -6,7 +6,7 @@ Code sharing and reuse via an FFI is fundamentally different from source code "i
 
 However, if the compiled resources we wish to link to were built with a different language (or even a different compiler of the same language), the bits and bytes may not line up properly when we push arguments, make calls, and retrieve results, due to the different standards that the other code's compiler followed when the borrowed code was produced.  In this case, more detailed bookkeeping must be followed by our language to make ABI translations and ensure that differences in issues such as data alignment, byte ordering, calling conventions, garbage collection, pointer references, and so forth are accounted for.  Without this, we risk not only getting incorrect results \-\- we could crash our process (or even the operating system).
 
-Although in theory FFI interfaces can be defined to link any pair of differing languages, most languages are designed to interact with libraries written in the C language.  This is because C has a long heritage and widespread use, and (importantly) C has a predictable, standardized way to compile functions and structures.  So with Pharo also choosing C as an FFI target we gain two major advantages: first, by basing ourselves on such "standard" formats, we can build tools that simplify interoperability with an extensive array of existing C libraries.  Second, since nearly every other language is doing the same, we can simply join those mutual C-standard ABIs together to form a bridge between different systems \-\- allowing us to program at the source level of a C API.
+While in theory FFI interfaces can be defined to link any pair of differing languages, most languages are designed to interact with libraries written in the C language.  This is because C has a long heritage and widespread use, and (importantly) C has a predictable, standardized way to compile functions and structures.  So with Pharo also choosing C as an FFI target we gain two major advantages: first, by basing ourselves on such "standard" formats, we can build tools that simplify interoperability with an extensive array of existing C libraries.  Second, since nearly every other language is doing the same, we can simply join those mutual C-standard ABIs together to form a bridge between different systems \-\- allowing us to program at the source level of a C API.
 
 This booklet shows one such FFI definition for Pharo: the Unified FFI framework, or uFFI for short.
 
@@ -54,7 +54,7 @@ FFITutorial class >> ticksSinceStart [
 
 where =='libc.so.6'== refers to the current version of the C shared library on our host system.  (We can find out which version we have by entering ==ls -1 /lib/*/libc.so*== in a Linux terminal window.)
 
-To define the same thing on other platforms, we need to replace the =='libc.so.6'== string by e.g., =='libc.dylib'== if we're running on OSX, or =='msvcrt.dll'== if we use Windows. The equivalent definitions for OSX and Windows are then:
+To define the same binding for other platforms, we need to replace the =='libc.so.6'== string by e.g., =='libc.dylib'== if we're running on MacOS, or =='msvcrt.dll'== if we use Windows. The equivalent definitions for MacOS and Windows are then:
 
 [[[language=smalltalk
 FFITutorial class >> ticksSinceStart [
@@ -79,6 +79,7 @@ FFITutorial ticksSinceStart
 If everything works as expected, this expression will return the number of native clock ticks since our Pharo process was launched.
 
 !!! Analyzing the FFI Call-Out
+@OriginalTicksSinceStartBinding
 
 The simple example we ran in the previous section illustrates several important uFFI concepts.
 For starters, let's look at the binding definition again:
@@ -93,33 +94,33 @@ This call-out binding, a Pharo method, is called ==ticksSinceStart== and happens
 Indeed, uFFI does not impose any restrictions as far as how to call your external functions.  This can come in handy for decoupling your methods from underlying C-level implementation details.
 
 We invoke the C function using the Pharo method ==ffiCall:module:==, which is defined by uFFI.  We assemble the message arguments it needs by deconstructing the target C function declaration and referencing the name of the library in which it's defined.  uFFI takes the pieces and performs all the necessary work to make the call-out.  Continuing our example, we see that uFFI:
-- Locates the specified library (==libc==, ==msvcrt==, ...) in our host system,
-- Loads the C library into memory,
-- Indexes the ==clock== function in the library,
-- Transforms and pushes our Pharo arguments onto the stack,
+- Searches for the specified library in our host system,
+- On finding it, loads the C library into memory,
+- Indexes the specified function within the library,
+- Transforms and pushes our Pharo arguments (if any) onto the stack,
 - Performs the call to the C function,
-- And finally transforms the return value (==uint== type) into a Pharo integer object.
+- And finally transforms the return value into a Pharo object.
 
 We said above that we need to "deconstruct" the C function declaration in order to create the first argument in our ==ffiCall:module:== message.  This argument is a Pharo Array of String, where each string element is a piece of the C declaration; we simply list the pieces in the same sequence as the C declaration.  The uFFI makes sense of it, and dynamically creates a C call with this information.
 
-This is best understood by example, so, to continue with our previous example, we render our C declaration in Pharo as:
+This is best understood by example, so, to continue with our previous, we render our C declaration in Pharo as a literal string array, like so:
 
 [[[
 #( uint clock () )
 ]]]
 
-The first element of our array is ==unit==, which is the function return ''type''.  This is followed by the function name, ==clock==.  Following the function name \-\-and note the space!\-\- we embed another Pharo Array to list the formal arguments the C function expects, in order. In this case, ==clock== takes no arguments, so we must provide an empty Array.
+The first element of our array is ==uint==, which is the function return ''type''.  This is followed by the function name, ==clock==.  Following the function name \-\-and note the space!\-\- we embed another Pharo Array to list the formal arguments the C function expects, in order. In this case, ==clock== takes no arguments, so we must provide an empty Array.
 
 Another way to think of it is this: If we look past the outer ==#()== Pharo syntax, what we see inside is our C function prototype, appearing very similar to normal C syntax (but with spaces in unusual places).  uFFI was intentionally defined this way so that in most cases we can simply copy-paste a C function declaration taken from a header file or documentation, add some required spaces, wrap it in ==#()==, and it's ready for use.
 
-Our ==ffiCall:module:== message also takes a second argument (=='libc.so.6'== in our Linux example), which is the name of the library that contains the function.  In many cases we do not need to provide a full path to the file in our host system.  However, it should already be apparent that our bindings can be platform dependent, if the library we need is also platform-dependent.  We will explore how to define bindings in a platform-independent way in the following section.
+Our ==ffiCall:module:== message also takes a second argument (=='libc.so.6'== in our Linux example), which is the name of the library that contains the function.  In many cases we do not need to provide a full path to the file in our host system.  However, it should already be apparent that our bindings can be platform dependent, if the library we need is also platform-dependent.  We will explore how to define bindings in a platform-independent way in a following section.
 
 
 !!! Notes on Value Marshalling
 
 To fully understand the previous example, we still need to explain how the C ==uint== return value (a non-object; a cluster of bytes popped off the stack) gets transformed into a Pharo ==SmallInteger== ''object''.  Remember, C does not understand objects and does not do us the favor of returning values as attributes embedded within an object; we must somehow create an appropriate type of Pharo object, then migrate the C return value to become ''its'' value.  Our code then receives this Pharo object.
 
-This process of converting values between different internal representations is called ''marshalling'', and is, in most cases, managed automatically in Pharo by uFFI.  For example, uFFI internally maps these standard C values to Smalltalk objects:
+This process of converting values between different internal representations is called ''marshalling'', and in most cases is managed automatically in Pharo by uFFI.  For example, uFFI internally maps these standard C values to Smalltalk objects:
 - Types ==int==, ==uint==, ==long==, ==ulong== are mapped to Pharo integers (small or long integers, depending on the platform architecture).
 - Types ==float== and ==double== are mapped to Pharo floats.
 
@@ -188,7 +189,7 @@ MyLibC >> win32ModuleName [
 ]
 ]]]
 
-To use this improved technique, we modify our ''original'' binding method (in Section 1.2) to substitute our library in place of the library name string:
+To use this improved technique, we modify our ''original'' binding method (in *@OriginalTicksSinceStartBinding*) to substitute our library in place of the library name string:
 
 [[[language=smalltalk
 FFITutorial class >> ticksSinceStart [
@@ -288,8 +289,8 @@ Of course, bindings defining a library explicitly will necessarily override this
 In this chapter we have seen the basics of writing our own uFFI call-outs. We declare an FFI binding to a C function by specifying the name of the function, its return type, its arguments, and the library the function belongs to. uFFI uses this information to load the library in memory, look up the function, demarshall our Pharo arguments to C types and push them, call the function, and marshall any C return values back into Pharo objects.
 
 [[[language=smalltalk
-FFITutorial class >> ticksSinceStart [
-	^ self ffiCall: #( uint clock () )
+FFITutorial class >> time [
+	^ self ffiCall: #( uint time ( NULL ) )
 ]
 ]]]
 

--- a/Chapters/2-marshalling.pillar
+++ b/Chapters/2-marshalling.pillar
@@ -1,42 +1,42 @@
 !! Marshalling and Function Arguments
 
-In the last chapter we have seen the basics of FFI callouts to define a FFI binding to a function.
-This first example introduced the ideas of function lookup, library and marshalling of return values.
-However, the idea of marshalling is not specific to the transformation of return values from C to Pharo: it also involves the transformation of Pharo values to C, and the sharing of values between them.
+In the last chapter we looked at the basics of FFI call\-outs to define a Pharo uFFI binding to a function.
+These first examples introduced the concepts of function lookup, library references, and marshalling of return values.
+However, the idea of marshalling is not specific to the transformation of return values from C to Pharo: it also involves the transformation of Pharo values to C, and the sharing of values between the two.
 
-This chapter presents marshalling more in detail, using function arguments as our main case study.
+This chapter presents marshalling in more detail, focusing on function arguments.
 Our first examples show uFFI's capability of using literals as default argument values.
-We then advance into other basic data types such as Strings and ByteArrays, and finally to C pointers and how to manipulate them from Pharo.
-This chapter finishes by presenting the different marshalling rules in uFFI for basic types and particularly how to manage platform-specific types.
+We then advance to other basic data types, from Strings and ByteArrays all the way to C pointers and how to manipulate them within Pharo.
+This chapter finishes by presenting the different marshalling rules in uFFI for basic types, particularly how to manage platform-specific types.
 
 !!! A First Function Argument
 
-The previous ==clock== example was the one of the simplest examples possible as it does not receive any arguments and we could easily tweak the binding to map the return value to an unsigned integer.
-To study function arguments let's consider the ==abs()== function, which receives an integer argument and returns its absolute value.
-The function prototype of ==abs()==, available in the standard C library as our previous examples, looks as follows:
+Our previous ==clock== example was the one of the simplest uFFI examples possible, as it does not require passing any arguments, and because we could easily tweak the binding to map the return value to an unsigned integer.
+To understand how to deal with function arguments, let's consider the ==abs()== function, which receives an integer argument and returns its absolute value.
+The function prototype of ==abs()==, available in the standard C library as in our previous examples, is declared as follows:
 
 [[[
-int abs ( int n );
+int abs( int n );
 ]]]
 
-To create a binding for such a function requires that we somehow provide an ==n== argument in our binding.
-To ease argument bindings, uFFI automatically matches the parameter names in our methods to the corresponding function parameters, if they have the same name.
+To create a binding for such a function requires that we somehow provide an ==int== argument in our binding.
+To ease the construction of argument bindings, uFFI will automatically match the parameter names in our calling method to any corresponding function parameters that have the same name.
 In other words, we can define our binding for ==abs()== as a method with a single ==n== argument as follows:
 
 [[[language=smalltalk
 FFITutorial class >> abs: n [
-	^ self ffiCall: #( int abs (int n) )
+	^ self ffiCall: #( int abs ( int n ) )
 ]
 ]]]
 
-Creating this binding does not really add any extra complexity to the ones done in previous examples.
-We create a simple method using the ==ffiCall:== message, and we provide as argument an array with a copy of the function's prototype.
-The only visible addition is the introduction of the ==n== parameter, but no manual work was required to transform Pharo's object to a C value.
-We can even rename that parameter using a more Pharoish style, let's say ==anInteger==.
+Creating this binding does not really add any extra complexity to what we did in our previous examples.
+We create a simple method that uses the ==ffiCall:== message, providing it an Array argument with a copy of the function's prototype.
+The only visible addition is the introduction of the ==n== parameter, but no additional work was needed to transform Pharo's object to a C value.
+We can even rename the parameter to use a more Pharo''ish'' naming style, such as ==anInteger==\:
 
 [[[language=smalltalk
 FFITutorial class >> abs: anInteger [
-	^ self ffiCall: #( int abs (int anInteger) )
+	^ self ffiCall: #( int abs ( int anInteger ) )
 ]
 ]]]
 
@@ -307,7 +307,7 @@ the relationship between both strings.
 ""Smalltalk binding""
 [[[language=smalltalk
 FFICExamples class >> stringCompare: aString with: anotherString [
-	^ self ffiCall: #( int strcmp (String aString, String anotherString) ) module: LibC	
+	^ self ffiCall: #( int strcmp (String aString, String anotherString) ) module: LibC
 ]
 ]]]
 

--- a/Chapters/2-marshalling.pillar
+++ b/Chapters/2-marshalling.pillar
@@ -2,18 +2,18 @@
 
 In the last chapter we looked at the basics of FFI call\-outs to define a Pharo uFFI binding to a function.
 These first examples introduced the concepts of function lookup, library references, and marshalling of return values.
-However, the idea of marshalling is not specific to the transformation of return values from C to Pharo: it also involves the transformation of Pharo values to C, and the sharing of values between the two.
+However, the idea of marshalling is not specific to the transformation of return values from C to Pharo: it also involves the transformation of Pharo values to C, and the sharing of values between the two environments.
 
 This chapter presents marshalling in more detail, focusing on function arguments.
 Our first examples show uFFI's capability of using literals as default argument values.
-We then advance to other basic data types, from Strings and ByteArrays all the way to C pointers and how to manipulate them within Pharo.
+We then advance to other basic data types, from ==String==s and ==ByteArray==s all the way to C pointers and how to manipulate them within Pharo.
 This chapter finishes by presenting the different marshalling rules in uFFI for basic types, particularly how to manage platform-specific types.
 
 !!! A First Function Argument
 
 Our previous ==clock== example was the one of the simplest uFFI examples possible, as it does not require passing any arguments, and because we could easily tweak the binding to map the return value to an unsigned integer.
-To understand how to deal with function arguments, let's consider the ==abs()== function, which receives an integer argument and returns its absolute value.
-The function prototype of ==abs()==, available in the standard C library as in our previous examples, is declared as follows:
+To understand how to deal with function arguments, let\'s consider the ==abs()== function, which receives an integer argument and returns its absolute value.
+The prototype of ==abs()==, another function available in the standard C library (allowing us to use our previous tutorial class), is declared as follows:
 
 [[[
 int abs( int n );
@@ -30,8 +30,10 @@ FFITutorial class >> abs: n [
 ]]]
 
 Creating this binding does not really add any extra complexity to what we did in our previous examples.
-We create a simple method that uses the ==ffiCall:== message, providing it an Array argument with a copy of the function's prototype.
-The only visible addition is the introduction of the ==n== parameter, but no additional work was needed to transform Pharo's object to a C value.
+We create a simple method that uses the ==ffiCall:== message, providing it an array argument enclosing a copy of the function's prototype.  (As with our earlier ==FFITutorial== class methods, we're assuming the continued use of our ==ffiModuleName== override to eliminate the need to add the ==module:== keyword).
+
+The part that's new here is the introduction of the ==n== parameter and its C type, but no additional work is needed on our part to transform Pharo's object to a C value.  Also, notice that uFFI knows to distinguish the argument's declared ''type'' from its formal parameter ''name'', while simultaneously matching up the name with our Pharo method's formal argument.
+
 We can even rename the parameter to use a more Pharo''ish'' naming style, such as ==anInteger==\:
 
 [[[language=smalltalk
@@ -40,7 +42,7 @@ FFITutorial class >> abs: anInteger [
 ]
 ]]]
 
-Finally, we can now use this binding from a playground as follows, with a regular Pharo SmallInteger.
+Finally, we can now use this binding from a playground as follows, with a regular Pharo ==SmallInteger==\:
 
 [[[language=smalltalk
 FFITutorial abs: -42.
@@ -48,104 +50,110 @@ FFITutorial abs: -42.
 
 !!! Marshalling
 
-Again, it was uFFI that managed value transformations for us.
-This transformation may look like uFFI simply copies the Pharo integer value to the C memory.
-However, these marshalling rules are not as straight forward, as Pharo and C use different data representations for each different data-type, and is potentially modified per platform.
+As we saw with return values in Chapter 1, Pharo's uFFI also manages the transformation of function arguments for us. The syntax we use may give the impression that uFFI simply copies the Pharo integer value to the C stack; however, the marshalling rules that uFFI must follow are not that straight-forward.  Pharo and C use different internal representations for their data types, each of which must be modified in order to be exchanged, and potentially in different ways, depending on the host platform.
 
-To illustrate how marshalling works, let's consider the marshalling of a SmallInteger to a C ==int== type as in the example.
-Internally, to differentiate integers from object pointers, Pharo represents SmallIntegers with an extra bit tagging the value.
-Let's consider the SmallInteger 2, represented in binary as the number 10, and is internally represented by Pharo as 101.
-This ''representation mismatch'' requires that uFFI transforms small integers to C ==int==s as follows:
-- a Pharo small integer transformed in a C value needs to be shifted to the right, ==101 >> 1==, transforming 101 to 10.
-- a C integer transformed in a Pharo small integer needs to be shifted to the left and added 1, ==(10 << 1) + 1==, transforming 10 to 101.
+To illustrate how marshalling works, let\'s consider the marshalling of a Pharo ==SmallInteger== to a C ==int== type, as in our example.
+Internally, for efficiency purposes, Pharo represents ==SmallInteger==s directly in binary, rather than as an object pointed to in the heap.  Therefore, to differentiate integers from object pointers, Pharo tags ==SmallInteger== \"pointers\" with an extra bit to signify this special interpretation.
+
+Let\'s consider the ==SmallInteger 2==; this value is represented in binary as the number ==2r10==, but is internally represented in Pharo as ==2r101==, where the ''least'' significant bit is shifted in as the added tag.  Since all Pharo object pointers are at least 32-bit aligned, we're guaranteed that their least significant bit will always be zero.  This makes a non-zero LSB a reliable indicator that we're dealing with a ==SmallInteger== rather than a heap pointer.  This is also why Pharo ==SmallInteger==s are 31 bits, ''not'' 32.
+
+This resulting ''representation mismatch'' requires that the uFFI transform small integers to C ==int==s (and vice\-versa) as follows:
+- a Pharo small integer transformed to a C value needs to be logically shifted to the right, ==2r101 >> 1==, transforming ==2r101== to ==2r10==.
+- a C integer (representable in 31 bits or less) transformed to a Pharo small integer needs to be shifted to the left and incremented, ==(2r10 << 1) + 1==, transforming ==2r10== to ==2r101==.
 
 !!!! Pharo-to-C Marshalling
 
-When marshalling Pharo objects to C, uFFI decides the rule of marshalling to use depending on two pieces of information.
-On the one hand, it uses the concrete type of the marshalled object ''its class''.
-On the other hand, it uses the type defined in the function binding as the target transformation type.
-At run time, when the binding method is executed, uFFI takes the type of the binding argument and transforms the argument object to the C representation of that type, doing a ''cast'' if necessary. This transformation rules has several consequences, that we will illustrate in several cases using our running ==abs== example:
+When marshalling Pharo objects to C, uFFI decides the transformation rule to use depending on two pieces of information.
+First, it considers the concrete type of the marshalled Pharo object, ''its class''.
+Second, it considers the C type defined in the function binding as the target transformation type.
+At run time, when the binding method is executed, uFFI reads the type of the binding argument and transforms the argument object to the indicated C type's representation, performing a type cast/coercion as necessary.
 
-- SmallIntegers are transformed to ==int==s as expected.
+These transformation rules have several consequences, which we will illustrate with several cases, using our previous ==abs== function example.
+
+- ==SmallInteger==s are transformed to ==int==s as expected (since they cannot overflow)\:
 
 [[[language=smalltalk
 FFITutorial abs: -42.
 => 42
 ]]]
 
-- Integers that overflow the ==int== size are casted/cut down, producing results similar to what a C program would produce.
+- Pharo integers that overflow the C ==int== size are coerced by truncating to size, producing results similar to what a C program would produce\:
 
 [[[language=smalltalk
-FFITutorial abs: SmallInteger maxVal.
+FFITutorial abs: SmallInteger maxVal.  "Cast to all 1\'s"
 => 1
 ]]]
 
-- Floats used for ==int==s will be automatically casted and only their integer part retained
+- Pharo floats provided for C ==int== arguments will be truncated to produce an integer\:
 
 [[[language=smalltalk
 FFITutorial abs: Float pi.
 => 3
 ]]]
 
-- Objects non compatible with the ==int== type are rejected and an exception is thrown
+- Pharo objects that are incompatible with C ==int== type are rejected, and an exception is thrown\:
 
 [[[language=smalltalk
 FFITutorial abs: Object new.
-=> exception!
+=> Error: Could not coerce arguments
 ]]]
 
 !!!! C-to-Pharo Marshalling
 
-A similar-yet-different story happens when marshalling C values to Pharo objects.
-In this case uFFI decides the rule of marshalling depending on just the specified return type.
-At run time, when the binding method is executed and the function returns, uFFI transforms the returned value to the closest Pharo type for the specified C type.
-For example, the ==int== type will interpret the returned data as SmallIntegers or Positive/Negative/LargeIntegers depending on their size and sign,
-the ==float== type will interpret the returned data as Float.
+A similar\-yet\-different story happens when marshalling C values to Pharo objects.
+In this case uFFI decides the marshalling rule based on just the specified return type.
+At run time, when the binding method is executed and the C function returns, uFFI transforms the (expected) return value into the closest Pharo type corresponding to the declared C type.
+
+For example, a delared ==int== return type will cause uFFI to interpret the returned value as either a ==SmallInteger== or ==Large(Positive\|Negative)Integer==, depending on the size and sign of the data; a C
+==float== or ==double== type will interpret the returned data as a Pharo ==Float==.
 
 !!!! Marshalling of Incorrectly Declared Types
 
-The marshalling rules we have seen above show that the way in which we specify function types is crucial to the correct behaviour of our bindings, and thus our applications.
-In other words, bindings require that types are correctly specified, runtime errors, or even worse, incorrect value transformation may happen.
-Let's consider as an example what happens if we modify the signature of the ==abs== function to use a ==float== as argument.
+The marshalling rules we have seen above show that the way in which we specify function types is ''crucial'' to the correct behavior of our bindings, and thus our applications.
+In other words, call\-out bindings require that C types are correctly specified, otherwise run\-time errors \-\- or even worse, viable but incorrect value transformations \-\- may happen.
+
+Let\'s consider as an example what happens if we create a companion ==abs== function to operate on a ==Float== argument instead of an integer, but which uses the same C ==abs== function\:
 
 [[[language=smalltalk
 FFITutorial class >> floatAbs: aFloat [
-	^ self ffiCall: #( int abs (float aFloat) )
+	^ self ffiCall: #( int abs ( float aFloat ) )
 ]
 ]]]
 
-And then we evaluate in a playground our binding with a negative float value:
+Now let\'s we evaluate this version in a playground using a negative ==Float== value:
 
 [[[language=smalltalk
 FFITutorial floatAbs: -1.0.
 => 0
 ]]]
 
-Although we expected the message to return 1 (because the return value is still of type ==int==), this example returns 0.
-To understand this result, we need to first understand that our bindings, and the way we expressed their types, are independent of the actual function implementation we are calling.
-In other words, even if we set the type of ==abs== to ==float==, the ==abs== function in our system was built and compiled to work on ==int== values.
-So what happens under the hoods in this example is that uFFI transforms our -1.0 Pharo float to a C float, and then uses that value as if it was an integer.
-And it happens that integers and floats have different representations in C.
-This produces both hillarious and dangerous results.
+Although we expected the message to return ==1== (because the return value is still of type ==int==), this example returns ==0==.
+To understand this result, we need to understand that our bindings, and the way we express their C types, are ''independent'' of the actual function implementation we are calling.
+In other words, even if we \'set\' the type of ==abs== to ==float==, the ==abs== function in our system remains built and compiled to work only on C ==int== values.  We're not ''compiling'' the C functions in Pharo, only attaching and calling them.  So we must strictly and carefully adhere to their documented function declarations.
+
+What happens \"under the hood\" in this example is that uFFI transforms our ==\-1.0== Pharo float into a C float, then pushes it on the stack and calls the ==abs== function.  The function uses that value, but considers it to be an integer.
+And it happens that integers and floats have the same bit size (32 bits), but vastly different representations in C.
+This produces either hilarious or ''dangerous'' results...
 
 A similar problem arises if the return type of a function is incorrectly specified.
-Let's take for example a slightly modified version of our ==abs== binding for float return types:
+Let\'s take for example a slightly modified version of our original ==abs== binding, this time declaring a C float return type\:
 
 [[[language=smalltalk
 FFITutorial class >> floatReturnAbs: anInteger [
-	^ self ffiCall: #( float abs (int anInteger) )
+	^ self ffiCall: #( float abs ( int anInteger ) )
 ]
 ]]]
 
-Whenever this function returns, it will interpret the returned value as a float.
-However, as the actual implementation of ==abs== returns an ==int==, the integer is just wrongly interpreted producing strange values.
+When this call returns, uFFI will interpret the returned value as a C float, and try to marshall it to a Pharo ==Float==\:
 
 [[[language=smalltalk
-FFITutorial floatReturnAbs: Float pi.
-=> 3.3702805504e12
+FFITutorial floatReturnAbs: -3.
+=> -1.07374176e8
 ]]]
 
-Although writing library bindings with uFFI is fun and simple, the binding developer needs to make sure that the types are correctly declared, and that the correct version of the library is used. Fortunately, for mature libraries most of the times it is enough to copy and paste the function declarations.
+However, since the implementation of ==abs== actually returns an ==int==, the bits are wrongly interpreted, producing not an error (in this case), but a strange value \-\- ''one that your application might not detect''.  And if this kind of misinterpretation is only \"slightly off\", it can lead to buggy behavior that is maddeningly difficult to diagnose.
+
+While writing library bindings with uFFI is fun and simple, the binding developer needs to make sure that the types are correctly declared, and that the correct version of the library is being used. Fortunately, for mature libraries, most of the time it is sufficient to simply copy and paste the function declarations.
 
 !!! Function Argument Bindings
 
@@ -159,7 +167,7 @@ For example, they may have extra parameters for optional options and configurati
 Although ''optional'', we cannot leave these parameters out of the binding, as they need to be there for the call to happen correctly.
 To cope with optional parameters, uFFI allows literal objects to be sent as function arguments.
 
-To illustrate this, let's first imagine that for some reason we need to call the ==abs== function with the -42 argument exclusively.
+To illustrate this, let\'s first imagine that for some reason we need to call the ==abs== function with the -42 argument exclusively.
 With the tools we have seen until now, a simple way to define such a binding would be to define a normal Pharo method calling our binding with the value -42.
 
 [[[language=smalltalk

--- a/Chapters/2-marshalling.pillar
+++ b/Chapters/2-marshalling.pillar
@@ -229,10 +229,11 @@ FFITutorial class >> absMinusFortyTwo [
 ]
 ]]]
 
-As with class-variables, uFFI integrates with variables defined in shared pools.
-Shared pools are useful to group common constants that need to be shared between different classes, bindings or even libraries.
+Just as with class variables, uFFI integrates transparently with variables defined in shared pools.
+Shared pools are useful for grouping common constants that need to be shared between different classes, bindings, or even libraries.
+
 The following code illustrates how we can modify our code to put our variable(s) in a shared pool.
-Notice that the only code that changes is the one defining the variable.
+Notice that the only code that changes is the class defining the variable.
 The binding using the variable remains unchanged.
 
 [[[language=smalltalk
@@ -242,6 +243,7 @@ SharedPool subclass: #FFITutorialPool
   ...
 
 FFITutorialPool class >> initialize [
+	"Set this to -42 because.. Life, the Universe, and Everything"
 	TheAnswer := -42.
 ]
 
@@ -251,26 +253,24 @@ Object subclass: #FFITutorial
   ...
 
 FFITutorial class >> absMinusFortyTwo [
-  ^ self ffiCall: #( int abs ( (int) TheAnswer) ) module: LibC
+  ^ self ffiCall: #( int abs ( (int) TheAnswer ) )
 ]
 ]]]
 
+Using a shared pool does not change the normal Pharo usage of uFFI. If you want to learn more about Pharo shared pools, we recommend you take a look at ''Pharo by Example 8.0''.
 
-Using a shared pool does not change from the normal Pharo usage. If you want to know shared pools more in detail, we recommend you take a look at Pharo by Example.
+We can also pass ==self== as an argument to a C call.
+Suppose we want to add the ==abs()== function call to an extention of the class ==SmallInteger==, in a method named  ==absoluteValue==.  This would allows us to write expressions such as ==\-50 absoluteValue==.
 
-
-You can also pass ==self== or any instance variable as arguments to a C call.
-Suppose you want to add the ==abs== function binding to the class ==SmallInteger== in a method named  ==absoluteValue==, so that we can execute ==-50 absoluteValue==.
-
-In that case we simply add the ==absoluteValue== method to ==SmallInteger==, and we directly pass ==self== as illustrated below.
+To do this, we simply add an ==absoluteValue== method to ==SmallInteger== and directly pass ==self== as a (typed) argument, like so\:
 
 [[[language=smalltalk
 SmallInteger >> absoluteValue [
-	^ self ffiCall: #( int abs (int self) ) module: LibC
+	^ self ffiCall: #( int abs ( int self ) ) module: LibC
 ]
 ]]]
 
-It is is also possible to pass an instance variable, but we let you do it as an exercise :)
+It is is also possible to pass instance variables, but we let you experiment with that as an exercise... \:\^)
 
 !!! uFFI Data Types
 

--- a/Chapters/2-marshalling.pillar
+++ b/Chapters/2-marshalling.pillar
@@ -68,7 +68,7 @@ First, it considers the concrete type of the marshalled Pharo object, ''its clas
 Second, it considers the C type defined in the function binding as the target transformation type.
 At run time, when the binding method is executed, uFFI reads the type of the binding argument and transforms the argument object to the indicated C type's representation, performing a type cast/coercion as necessary.
 
-These transformation rules have several consequences, which we will illustrate with several cases, using our previous ==abs== function example.
+These transformation rules have several consequences, which we will illustrate with several cases, using our previous ==abs:== binding example.
 
 - ==SmallInteger==s are transformed to ==int==s as expected (since they cannot overflow)\:
 
@@ -112,7 +112,7 @@ For example, a delared ==int== return type will cause uFFI to interpret the retu
 The marshalling rules we have seen above show that the way in which we specify function types is ''crucial'' to the correct behavior of our bindings, and thus our applications.
 In other words, call\-out bindings require that C types are correctly specified, otherwise run\-time errors \-\- or even worse, viable but incorrect value transformations \-\- may happen.
 
-Let\'s consider as an example what happens if we create a companion ==abs== function to operate on a ==Float== argument instead of an integer, but which uses the same C ==abs== function\:
+Let\'s consider as an example what happens if we create a companion ==abs:== binding to operate on a ==Float== argument instead of an integer, but which uses the same C ==abs()== function\:
 
 [[[language=smalltalk
 FFITutorial class >> floatAbs: aFloat [
@@ -129,14 +129,14 @@ FFITutorial floatAbs: -1.0.
 
 Although we expected the message to return ==1== (because the return value is still of type ==int==), this example returns ==0==.
 To understand this result, we need to understand that our bindings, and the way we express their C types, are ''independent'' of the actual function implementation we are calling.
-In other words, even if we \'set\' the type of ==abs== to ==float==, the ==abs== function in our system remains built and compiled to work only on C ==int== values.  We're not ''compiling'' the C functions in Pharo, only attaching and calling them.  So we must strictly and carefully adhere to their documented function declarations.
+In other words, even if we \'set\' the type of ==abs()== to ==float==, the ==abs()== function in our system remains built and compiled to work only on C ==int== values.  We're not ''compiling'' the C functions in Pharo, only attaching and calling them.  So we must strictly and carefully adhere to their documented function declarations.
 
-What happens \"under the hood\" in this example is that uFFI transforms our ==\-1.0== Pharo float into a C float, then pushes it on the stack and calls the ==abs== function.  The function uses that value, but considers it to be an integer.
+What happens \"under the hood\" in this example is that uFFI transforms our ==\-1.0== Pharo float into a C float, then pushes it on the stack and calls the ==abs()== function.  The function uses that value, but considers it to be an integer.
 And it happens that integers and floats have the same bit size (32 bits), but vastly different representations in C.
 This produces either hilarious or ''dangerous'' results...
 
 A similar problem arises if the return type of a function is incorrectly specified.
-Let\'s take for example a slightly modified version of our original ==abs== binding, this time declaring a C float return type\:
+Let\'s take for example a slightly modified version of our original ==abs:== binding, this time declaring a C float return type\:
 
 [[[language=smalltalk
 FFITutorial class >> floatReturnAbs: anInteger [
@@ -151,24 +151,24 @@ FFITutorial floatReturnAbs: -3.
 => -1.07374176e8
 ]]]
 
-However, since the implementation of ==abs== actually returns an ==int==, the bits are wrongly interpreted, producing not an error (in this case), but a strange value \-\- ''one that your application might not detect''.  And if this kind of misinterpretation is only \"slightly off\", it can lead to buggy behavior that is maddeningly difficult to diagnose.
+However, since the implementation of ==abs()== actually returns an ==int==, the bits are wrongly interpreted, producing not an error (in this case), but a strange value \-\- ''one that your application might not detect''.  And if this kind of misinterpretation is only \"slightly off\", it can lead to buggy behavior that is maddeningly difficult to diagnose.
 
 While writing library bindings with uFFI is fun and simple, the binding developer needs to make sure that the types are correctly declared, and that the correct version of the library is being used. Fortunately, for mature libraries, most of the time it is sufficient to simply copy and paste the function declarations.
 
 !!! Function Argument Bindings
 
-We have seen in the introductory example before how to use method parameters as arguments in our function bindings.
-In this section we explore other ways to define arguments, in particular literal integers, instance and class variables.
+We have seen in the earlier introductory example how to use method parameters as arguments when writing function bindings.
+In this section we explore other ways to define arguments, in particular literal integers, instance variables, and class variables.
 
 !!!! Literal Integer Arguments
 
-From time to time we will find C functions presenting much more parameters than the ones we are interested in.
-For example, they may have extra parameters for optional options and configurations, or even parameters that are only necessary in particular cases and ignored in others.
-Although ''optional'', we cannot leave these parameters out of the binding, as they need to be there for the call to happen correctly.
-To cope with optional parameters, uFFI allows literal objects to be sent as function arguments.
+From time to time we will find ourselves calling C functions that require many more parameters than the ones we are actually interested in providing.
+For example, C functions may have extra parameters to select or control certain options and configurations, or they may have parameters that are only necessary in particular cases (and which are ignored in others).
 
-To illustrate this, let\'s first imagine that for some reason we need to call the ==abs== function with the -42 argument exclusively.
-With the tools we have seen until now, a simple way to define such a binding would be to define a normal Pharo method calling our binding with the value -42.
+Although parameters such as these are deemed ''optional'', we cannot leave them out of our binding definition \-\- they still need to be there for the C call to occur correctly. To make it easier to deal with such optional parameters, uFFI allows Pharo literal objects to be provided as function arguments.
+
+To see how this works, let\'s first imagine that for some reason we needed to call the ==abs()== function with the ==\-42== argument exclusively.
+Using what we have learned up to this point, a simple way to define such a binding would be to define a normal Pharo method calling our binding with the hard-coded value ==\-42==\:
 
 [[[language=smalltalk
 FFITutorial class >> absMinusFortyTwo [
@@ -176,55 +176,56 @@ FFITutorial class >> absMinusFortyTwo [
 ]
 ]]]
 
-This approach is convenient one when we want both ==abs:== and ==absMinusFortyTwo== to be exposed to the final user.
-Ultimately it benefits from the binding being declared only once, so we can isolate potential marshalling mistakes in a single place.
-However, we do not always want to expose the ==abs== function directly as in this case.
-To cover this feature, uFFI supports the usage of literal arguments in function bindings.
-Instead of using a method parameter as argument in the function binding, we can specify a literal value.
+This approach is convenient when we want both ==abs:== and ==absMinusFortyTwo== to be exposed to our user.
+It certainly benefits from the binding being declared only once, allowing us to isolate potential marshalling mistakes in a single location.
+However, we may not want to couple to the ==abs:== method directly, as we\'re doing in this case.  Instead, we want to provide ==\-42== directly to the C ==abs()== function, as a literal (canned-in) value.
+
+To provide for this, uFFI supports the usage of literal arguments in function bindings.  Instead of using a method parameter as argument in the function binding, we can specify a literal value with some additional new syntax\:
 
 [[[language=smalltalk
 FFITutorial class >> absMinusFortyTwo [
-	^ self ffiCall: #( int abs ( (int) -42) ) module: LibC
+	^ self ffiCall: #( int abs ( (int) -42 ) )
 ]
 ]]]
 
-Literal integers should be accompanied with a type annotation like the ==(int)== above.
-This type information is needed by uFFI to correctly decide how to transform the integer, as many different variants may happen.
-Consider that C integers can be signed or unsigned, and occupy different sizes like 8, 16, 32, 64 bits...
-We will present more in detail the different data types accepted by uFFI, in particular integer data types, in a following section in this chapter.
+Notice that we don't just type in a Pharo integer for the expected argument; literal values such as integers must be preceded by a C type declaration, such as the ==(int)== above, in parenthesis (to make it clear to the parser that it\'s a ''type specifier'').
+This type information is needed by uFFI to correctly determine how to transform the Pharo integer, given the many different forms in which it could be rendered.
+
+Consider that in the case of C integers, a number can be signed or unsigned, and can occupy different sizes such as 8, 16, 32, or 64 bits.  Pharo can't guess; the C function expects a specific type to be provided, and the Pharo object containing the value doesn't reflect this.  We have to explicitly \'type\' the literal when we type it in.
+
+We will present more detail about the different data types accepted by uFFI, in particular integer data types, in an upcoming section of this chapter.
 
 !!!! Variables
 
-In the methods above we used literal numbers as arguments in ffi callouts.
-Although handy, these literal numbers enter in the category of ''magic numbers''.
-In other words, these literal numbers that lie in the code do not explain where those numbers came from, how they were chosen or calculated.
-One way to avoid the spread of magic numbers in the code is to assign names to them, usually done with variables or constants.
+In the methods above we used literal numbers as arguments in uFFI call\-outs.
+Although handy, these literal numbers fall into the category of so\-called \"magic numbers\"\: Embedded literals in code that offer no explanation of where they came from, why they were chosen, or how they were calculated.  (These are distinguished from ''manifest constants'', which are more-or-less self-explanatory, such as using ''pi'' in angle calculations or \'2\' when we need half of a quantity.)
 
-C libraries often define such constants using #define pre-processor statements like.
+Embedding magic numbers in methods is a ''code smell'' and should be avoided.  One way to handle these kinds of values is to parameterize them\: assign them names, usually as a variable or named constant.  C libraries often define such constants using ==\#define== pre-processor statements such as\:
 
 [[[language=c
   #define magicNumber -42
 ]]]
 
-In Pharo, we take a similar approach by defining our value in a class variable.
-We change the definition of the ==FFITutorial== class to include a class variable ==TheAnswer==, and define a class-side ==initialize== method to initialize the value. Do not forget to execute this ==initialize== method so the value is actually set.
+In Pharo, we can take a similar approach by defining such values in class variables.
+We only need to change the definition of our ==FFITutorial== class to include a class variable such as ==TheAnswer== (which is consequently capitalized), and then define a class-side ==initialize== method to set its value (''and explain why''). Do ""not"" forget to execute this ==initialize== method, otherwise the value won\'t get set\!
 
 [[[language=smalltalk
 Object subclass: #FFITutorial
 	...
-	classVariables: 'TheAnswer'
+	classVariableNames: 'TheAnswer'
   ...
 
 FFITutorial class >> initialize [
+	"Set this to -42 because.. Life, the Universe, and Everything"
 	TheAnswer := -42.
 ]
 ]]]
 
-Finally, we proceed to redefine our callout binding to use our class variable.
+Finally, we update our call\-out binding to use our class variable \-\- and note that we still need to provide its type explicitly\:
 
 [[[language=smalltalk
 FFITutorial class >> absMinusFortyTwo [
-  ^ self ffiCall: #( int abs ( (int) TheAnswer) ) module: LibC
+  ^ self ffiCall: #( int abs ( (int) TheAnswer) )
 ]
 ]]]
 


### PR DESCRIPTION
This is for the Intro & Sections 2.1 - 2.3; more on the way...

Issues:
- I was not able to run the literal number example in Section 2.3; it throws errors in P7 & P8.
- Does Pharo still use PoolDictionaries?  There's an example for this at the end of Section 2.3.
- Guille, is there a way to get a copy of the test build of the PDF that runs when a pull request/update is submitted?  I don't want to wait for Stef to create a new release in order to proof the output...