### PR TITLE
Copy-edits for uFFI booklet

### DIFF
--- a/Chapters/1-callouts.pillar
+++ b/Chapters/1-callouts.pillar
@@ -21,7 +21,7 @@ Suppose we want to know the amount of time the image has been running by calling
 named ==clock==. This function is part of the standard C library (==libc==). Its declaration in C is\:
 
 [[[
-clock\_t clock( void )\;
+clock_t clock( void );
 ]]]
 
 For the sake of simplicity, let\'s treat ==clock==\'s return type as an unsigned, ==uint==, instead of ==clock\_t==.
@@ -29,7 +29,7 @@ For the sake of simplicity, let\'s treat ==clock==\'s return type as an unsigned
 This results in the following C function declaration\:
 
 [[[
-uint clock( void )\;
+uint clock( void );
 ]]]
 
 To call ==clock== from Pharo using uFFI, we need to define a binding between a Pharo method and the ==clock== function.
@@ -41,14 +41,14 @@ To access the ==clock== function, we then define a method in our ==FFITutorial==
 
 If our Pharo code is hosted on a Linux system, we define this class and (class\-side) method like so\:
 
-[[[language\=smalltalk
-Object subclass\: \#FFITutorial
-	instanceVariableNames\: \'\'
-	classVariableNames\: \'\'
-	package\: \'FFITutorial\'
+[[[language=smalltalk
+Object subclass: #FFITutorial
+	instanceVariableNames: ''
+	classVariableNames: ''
+	package: 'FFITutorial'
 
 FFITutorial class >> ticksSinceStart [
-  \^ self ffiCall\: \#( uint clock() ) module\: \'libc.so.6\'
+  ^ self ffiCall: #( uint clock() ) module: 'libc.so.6'
 ]
 ]]]
 
@@ -56,23 +56,23 @@ where we have simply copied the C declaration into a Pharo Array literal, then a
 
 To define the same binding for other host platforms, we need to replace the ==\'libc.so.6\'== string by e.g., ==\'libc.dylib\'== if we\'re running on MacOS, or ==\'msvcrt.dll\'== if we use Windows. The equivalent definitions for MacOS and Windows are then\:
 
-[[[language\=smalltalk
+[[[language=smalltalk
 FFITutorial class >> ticksSinceStart [
-  \^ self ffiCall\: \#( uint clock() ) module\: \'libc.dylib\'
+  ^ self ffiCall: #( uint clock() ) module: 'libc.dylib'
 ]
 ]]]
 
 and
 
-[[[language\=smalltalk
+[[[language=smalltalk
 FFITutorial class >> ticksSinceStart [
-  \^ self ffiCall\: \#( uint clock() ) module\: \'msvcrt.dll\'
+  ^ self ffiCall: #( uint clock() ) module: 'msvcrt.dll'
 ]
 ]]]
 
 Finally, we can use our freshly\-created binding in a Pharo playground by inspecting or printing the following expression\:
 
-[[[language\=smalltalk
+[[[language=smalltalk
 FFITutorial ticksSinceStart
 ]]]
 
@@ -84,9 +84,9 @@ If everything works as expected, this expression will return the number of nativ
 The simple example we ran in the previous section illustrates several important uFFI concepts.
 For starters, let\'s look at the binding definition again\:
 
-[[[language\=smalltalk
+[[[language=smalltalk
 FFITutorial class >> ticksSinceStart [
-	\^ self ffiCall\: \#( uint clock() ) module\: \'libc.so.6\'
+	^ self ffiCall: #( uint clock() ) module: 'libc.so.6'
 ]
 ]]]
 
@@ -106,7 +106,7 @@ uFFI interprets the declaration and performs all the necessary work needed to ma
 To form the first argument in our example, we render our C declaration for ==clock== in Pharo as a literal string array, like so\:
 
 [[[
-\#( uint clock() )
+#( uint clock() )
 ]]]
 
 The first element of our array is ==uint==, which is the function return ''type''.  This is followed by the function name, ==clock==.  Following the function name, we embed another Pharo Array to list the formal arguments the C function expects, in order. In this case, ==clock== takes no arguments, so we must provide an empty Array.
@@ -138,27 +138,27 @@ So we could say that this solution is not portable enough\: One of the hallmark 
 
 One way to overcome this issue would be to define a set of bindings, one per platform, and decide which one to call based on which platform we detect at run\-time, as follows\:
 
-[[[language\=smalltalk
+[[[language=smalltalk
 FFITutorial class >> ticksSinceStart [
   self platform isWindows
-    ifTrue\: [ \^ self ticksSinceStartWindows ].
+    ifTrue: [ ^ self ticksSinceStartWindows ].
   self platform isUnix
-    ifTrue\: [ \^ self ticksSinceStartUnix ].
+    ifTrue: [ ^ self ticksSinceStartUnix ].
   self platform isOSX
-    ifTrue\: [ \^ self ticksSinceStartOSX ].
-  self error\: \'Non\-supported platform\'
+    ifTrue: [ ^ self ticksSinceStartOSX ].
+  self error: 'Non-supported platform'
 ]
 
 FFITutorial class >> ticksSinceStartUnix [
-  \^ self ffiCall\: \#( uint clock() ) module\: \'libc.so.6\'
+  ^ self ffiCall: #( uint clock() ) module: 'libc.so.6'
 ]
 
 FFITutorial class >> ticksSinceStartOSX [
-  \^ self ffiCall\: \#( uint clock() ) module\: \'libc.dylib\'
+  ^ self ffiCall: #( uint clock() ) module: 'libc.dylib'
 ]
 
 FFITutorial class >> ticksSinceStartWindows [
-  \^ self ffiCall\: \#( uint clock() ) module\: \'msvcrt.dll\'
+  ^ self ffiCall: #( uint clock() ) module: 'msvcrt.dll'
 ]
 ]]]
 
@@ -168,31 +168,31 @@ uFFI solves this problem by allowing us to use ''library objects'' instead of pl
 
 So for our example, we can now define such a library, ==MyLibC==, as follows (being careful to note that the methods are ''instance side'' overrides)\:
 
-[[[language\=smalltalk
-FFILibrary subclass\: \#MyLibC
-	instanceVariableNames\: \'\'
-	classVariableNames\: \'\'
-	package\: \'UnifiedFFI\-Libraries\'
+[[[language=smalltalk
+FFILibrary subclass: #MyLibC
+	instanceVariableNames: ''
+	classVariableNames: ''
+	package: 'UnifiedFFI-Libraries'
 
 MyLibC >> macModuleName [
-	\^ \'libc.dylib\'
+	^ 'libc.dylib'
 ]
 
 MyLibC >> unixModuleName [
-	\^ \'libc.so.6\'
+	^ 'libc.so.6'
 ]
 
 MyLibC >> win32ModuleName [
-	"While this is not a proper \'libc\', MSVCRT has the functions we need here."
-	\^ \'msvcrt.dll\'
+	"While this is not a proper 'libc', MSVCRT has the functions we need here."
+	^ 'msvcrt.dll'
 ]
 ]]]
 
 To use this improved technique, we modify our ''original'' binding method (in *@OriginalTicksSinceStartBinding*) to substitute our library object (as a class) in place of the library name string\:
 
-[[[language\=smalltalk
+[[[language=smalltalk
 FFITutorial class >> ticksSinceStart [
-	\^ self ffiCall\: \#( uint clock() ) module\: MyLibC
+	^ self ffiCall: #( uint clock() ) module: MyLibC
 ]
 ]]]
 
@@ -204,9 +204,9 @@ The ==macModuleName==, ==unixModuleName==, and ==win32ModuleName== methods allow
 
 For example, an alternative override for ==unixModuleName== can limit the search for ==libc== to load only from the ==/usr/lib/== directory on the host this way\:
 
-[[[
+[[[language=smalltalk
 MyLibC >> unixModuleName [
-	\^ \'/usr/bin/libc.so.6\'
+	^ '/usr/bin/libc.so.6'
 ]
 ]]]
 
@@ -216,18 +216,18 @@ To take a real\-world example, let\'s consider where the Cairo graphics library 
 
 In the example below, the Cairo library search method for Linux checks for the existence of the library in each of ==/usr/lib/i386\-linux\-gnu==, ==/usr/lib32==, and ==/usr/lib==, and if found, returns the absolute path to that file\:
 
-[[[language\=smalltalk
+[[[language=smalltalk
 CairoLibrary >> unixModuleName [
-		"On different flavors of Linux, the path to the library may differ, depending on the distro and whether the system is 32\- or 64\-bit."
+		"On different flavors of Linux, the path to the library may differ, depending on the distro and whether the system is 32- or 64-bit."
 
-		\#(
-			\'/usr/lib/i386\-linux\-gnu/libcairo.so.2\'
-			\'/usr/lib32/libcairo.so.2\'
-			\'/usr/lib/libcairo.so.2\')
-		do\: [ \:path \|
-			path asFileReference exists ifTrue\: [ \^ path ] ].
+		#(
+			'/usr/lib/i386-linux-gnu/libcairo.so.2'
+			'/usr/lib32/libcairo.so.2'
+			'/usr/lib/libcairo.so.2' )
+		do: [ :path |
+			path asFileReference exists ifTrue: [ ^ path ] ].
 
-		self error\: \'Cannot locate Cairo library. Please check that it is installed on your system.\'
+		self error: 'Cannot locate Cairo library. Please check that it is installed on your system.'
 ]
 ]]]
 
@@ -239,9 +239,9 @@ The ==time== function receives a (potentially null) C pointer and returns the cu
 We can define our new binding as follows, providing a ==NULL== pointer as the function argument.
 (We leave it to the reader to look up the definition of the C function and determine the purpose of this argument.)
 
-[[[language\=smalltalk
+[[[language=smalltalk
 FFITutorial class >> time [
-	\^ self ffiCall\: \#( uint time( NULL ) ) module\: MyLibC
+	^ self ffiCall: #( uint time( NULL ) ) module: MyLibC
 ]
 ]]]
 
@@ -249,17 +249,17 @@ Our new binding references the ==MyLibC== library we defined earlier, so the abo
 
 To continue our example,
 
-[[[language\=smalltalk
+[[[language=smalltalk
 FFITutorial class >> myLibrary [
-  \^ MyLibC
+  ^ MyLibC
 ]
 
 FFITutorial class >> ticksSinceStart [
-	\^ self ffiCall\: \#( uint clock() ) module\: self myLibrary
+	^ self ffiCall: #( uint clock() ) module: self myLibrary
 ]
 
 FFITutorial class >> time [
-	\^ self ffiCall\: \#( uint time( NULL ) ) module\: self myLibrary
+	^ self ffiCall: #( uint time( NULL ) ) module: self myLibrary
 ]
 ]]]
 
@@ -269,17 +269,17 @@ Any class defining a binding also has the option of defining a default library b
 
 Let\'s see how this further simplies things for us\:
 
-[[[language\=smalltalk
+[[[language=smalltalk
 FFITutorial class >> ffiLibraryName [
-  \^ MyLibC
+  ^ MyLibC
 ]
 
 FFITutorial class >> ticksSinceStart [
-	\^ self ffiCall\: \#( uint clock() )
+	^ self ffiCall: #( uint clock() )
 ]
 
 FFITutorial class >> time [
-	\^ self ffiCall\: \#( uint time( NULL ) )
+	^ self ffiCall: #( uint time( NULL ) )
 ]
 ]]]
 
@@ -289,9 +289,9 @@ Of course, bindings defining a library explicitly will necessarily override this
 
 In this chapter we have seen the basics of writing our own uFFI call\-outs. We declare an FFI binding to a C function by specifying the name of the function, its return type, its arguments, and the library the function belongs to. uFFI uses this information to load the library in memory, look up the function, demarshall our Pharo arguments to C types and push them, call the function, and marshall any C return values back into Pharo objects.
 
-[[[language\=smalltalk
+[[[language=smalltalk
 FFITutorial class >> time [
-	\^ self ffiCall\: \#( uint time( NULL ) )
+	^ self ffiCall: #( uint time( NULL ) )
 ]
 ]]]
 

--- a/Chapters/1-callouts.pillar
+++ b/Chapters/1-callouts.pillar
@@ -70,7 +70,7 @@ FFITutorial class >> ticksSinceStart [
 ]
 ]]]
 
-Finally, we can use our freshly\-created bindings in a Pharo playground by inspecting or printing the following expression\:
+Finally, we can use our freshly\-created binding in a Pharo playground by inspecting or printing the following expression\:
 
 [[[language\=smalltalk
 FFITutorial ticksSinceStart
@@ -93,7 +93,7 @@ FFITutorial class >> ticksSinceStart [
 This call\-out binding, a Pharo method, is called ==ticksSinceStart== and happens to be named differently than the C function we are calling.
 Indeed, uFFI does not impose any restrictions as far as how to call your external functions.  This can come in handy for decoupling your methods from underlying C\-level implementation details.
 
-We invoke the C function using the Pharo method ==ffiCall\:module\:==, which is defined by uFFI.  We provide the message arguments it needs usually by just copying and pasting the target C function declaration inside a Pharo Array literal, then referencing the name of the library in which it\'s defined (which is general will be platform\-dependent).
+We invoke the C function using the Pharo method ==ffiCall\:module\:==, which is defined by uFFI.  We provide the message arguments it needs usually by just copying and pasting the target C function declaration inside a Pharo Array literal, then referencing the name of the library in which it\'s defined (which in general will depend on our host platform).
 
 uFFI interprets the declaration and performs all the necessary work needed to make the call\-out and return the result.  In general,
 - uFFI searches for the specified library in the host system,
@@ -111,7 +111,7 @@ To form the first argument in our example, we render our C declaration for ==clo
 
 The first element of our array is ==uint==, which is the function return ''type''.  This is followed by the function name, ==clock==.  Following the function name, we embed another Pharo Array to list the formal arguments the C function expects, in order. In this case, ==clock== takes no arguments, so we must provide an empty Array.
 
-Another way to think of the declaration argument is this\: If we look past the outer ==\#( )== wrapper, what we see inside is our C function prototype, appearing very similar to normal C syntax.  This is possible due to the coincidental nature of Smalltalk syntax\: our use of strings and array notation in Pharo nicely mirrors how we write a C function declaration.  uFFI was intentionally designed to take advantage of this so that in most cases we can simply copy\-paste a C function declaration taken from a header file or documentation, wrap it in ==\#( )==, and it\'s ready for use\!
+Another way to think of the declaration argument is this\: If we look past the outer ==\#( )== wrapper, what we see inside is our C function prototype, appearing very similar to normal C syntax.  This convenience is possible due to the coincidental nature of Smalltalk syntax\: our use of strings and array notation in Pharo nicely mirrors how we write a C function declaration.  uFFI was intentionally designed to take advantage of this so that in most cases we can simply copy\-paste a C function declaration taken from a header file or documentation, wrap it in ==\#( )==, and it\'s ready for use\!
 
 Our ==ffiCall\:module\:== message also needs a second argument (==\'libc.so.6\'== in our Linux example), which is the name of the library in our host that contains the function.  In many cases we do not need to provide a full path to the file in our host system.  However, it should already be apparent that our bindings can be platform dependent if the library we need is also platform\-dependent.  We will explore how to define bindings in a platform\-independent way in a following section.
 

--- a/Chapters/2-marshalling.pillar
+++ b/Chapters/2-marshalling.pillar
@@ -5,7 +5,7 @@ These first examples introduced the concepts of function lookup, library referen
 However, the idea of marshalling is not specific to the transformation of return values from C to Pharo: it also involves the transformation of Pharo values to C, and the sharing of values between the two environments.
 
 This chapter presents marshalling in more detail, focusing on function arguments.
-Our first examples show uFFI's capability of using literals as default argument values.
+Our first examples show uFFI\'s capability of using literals as default argument values.
 We then advance to other basic data types, from ==String==s and ==ByteArray==s all the way to C pointers and how to manipulate them within Pharo.
 This chapter finishes by presenting the different marshalling rules in uFFI for basic types, particularly how to manage platform-specific types.
 
@@ -30,9 +30,9 @@ FFITutorial class >> abs: n [
 ]]]
 
 Creating this binding does not really add any extra complexity to what we did in our previous examples.
-We create a simple method that uses the ==ffiCall:== message, providing it an array argument enclosing a copy of the function's prototype.  (As with our earlier ==FFITutorial== class methods, we're assuming the continued use of our ==ffiModuleName== override to eliminate the need to add the ==module:== keyword).
+We create a simple method that uses the ==ffiCall:== message, providing it an array argument enclosing a copy of the function\'s prototype.  (As with our earlier ==FFITutorial== class methods, we\'re assuming the continued use of our ==ffiModuleName== override to eliminate the need to add the ==module:== keyword).
 
-The part that's new here is the introduction of the ==n== parameter and its C type, but no additional work is needed on our part to transform Pharo's object to a C value.  Also, notice that uFFI knows to distinguish the argument's declared ''type'' from its formal parameter ''name'', while simultaneously matching up the name with our Pharo method's formal argument.
+The part that\'s new here is the introduction of the ==n== parameter and its C type, but no additional work is needed on our part to transform Pharo\'s object to a C value.  Also, notice that uFFI knows to distinguish the argument\'s declared ''type'' from its formal parameter ''name'', while simultaneously matching up the name with our Pharo method\'s formal argument.
 
 We can even rename the parameter to use a more Pharo''ish'' naming style, such as ==anInteger==\:
 
@@ -50,12 +50,12 @@ FFITutorial abs: -42.
 
 !!! Marshalling
 
-As we saw with return values in Chapter 1, Pharo's uFFI also manages the transformation of function arguments for us. The syntax we use may give the impression that uFFI simply copies the Pharo integer value to the C stack; however, the marshalling rules that uFFI must follow are not that straight-forward.  Pharo and C use different internal representations for their data types, each of which must be modified in order to be exchanged, and potentially in different ways, depending on the host platform.
+As we saw with return values in Chapter 1, Pharo\'s uFFI also manages the transformation of function arguments for us. The syntax we use may give the impression that uFFI simply copies the Pharo integer value to the C stack; however, the marshalling rules that uFFI must follow are not that straight-forward.  Pharo and C use different internal representations for their data types, each of which must be modified in order to be exchanged, and potentially in different ways, depending on the host platform.
 
 To illustrate how marshalling works, let\'s consider the marshalling of a Pharo ==SmallInteger== to a C ==int== type, as in our example.
 Internally, for efficiency purposes, Pharo represents ==SmallInteger==s directly in binary, rather than as an object pointed to in the heap.  Therefore, to differentiate integers from object pointers, Pharo tags ==SmallInteger== \"pointers\" with an extra bit to signify this special interpretation.
 
-Consider the ==SmallInteger 2==; this value is represented in binary as the number ==2r10==, but is internally represented in Pharo as ==2r101==, where the ''least'' significant bit is shifted in as the added tag.  Since all Pharo object pointers are at least 32-bit aligned, we're guaranteed that their least significant bit will always be zero.  This makes a non-zero LSB a reliable indicator that we're dealing with a ==SmallInteger== rather than a heap pointer.  This is also why Pharo ==SmallInteger==s are 31 bits, ''not'' 32.
+Consider the ==SmallInteger 2==; this value is represented in binary as the number ==2r10==, but is internally represented in Pharo as ==2r101==, where the ''least'' significant bit is shifted in as the added tag.  Since all Pharo object pointers are at least 32-bit aligned, we\'re guaranteed that their least significant bit will always be zero.  This makes a non-zero LSB a reliable indicator that we\'re dealing with a ==SmallInteger== rather than a heap pointer.  This is also why Pharo ==SmallInteger==s are 31 bits, ''not'' 32.
 
 This resulting ''representation mismatch'' requires that the uFFI transform small integers to C ==int==s (and vice\-versa) as follows:
 - a Pharo small integer transformed to a C value needs to be logically shifted to the right, ==2r101 >> 1==, transforming ==2r101== to ==2r10==.
@@ -129,7 +129,7 @@ FFITutorial floatAbs: -1.0.
 
 Although we expected the message to return ==1== (because the return value is still of type ==int==), this example returns ==0==.
 To understand this result, we need to understand that our bindings, and the way we express their C types, are ''independent'' of the actual function implementation we are calling.
-In other words, even if we \'set\' the type of ==abs()== to ==float==, the ==abs()== function in our system remains built and compiled to work only on C ==int== values.  We're not ''compiling'' the C functions in Pharo, only attaching and calling them.  So we must strictly and carefully adhere to their documented function declarations.
+In other words, even if we \'set\' the type of ==abs()== to ==float==, the ==abs()== function in our system remains built and compiled to work only on C ==int== values.  We\'re not ''compiling'' the C functions in Pharo, only attaching and calling them.  So we must strictly and carefully adhere to their documented function declarations.
 
 What happens \"under the hood\" in this example is that uFFI transforms our ==\-1.0== Pharo float into a C float, then pushes it on the stack and calls the ==abs()== function.  The function uses that value, but considers it to be an integer.
 And it happens that integers and floats have the same bit size (32 bits), but vastly different representations in C.
@@ -188,10 +188,10 @@ FFITutorial class >> absMinusFortyTwo [
 ]
 ]]]
 
-Notice that we don't just type in a Pharo integer for the expected argument; literal values such as integers must be preceded by a C type declaration, such as the ==int== above.
+Notice that we don\'t just type in a Pharo integer for the expected argument; literal values such as integers must be preceded by a C type declaration, such as the ==int== above.
 This type information is needed by uFFI to correctly determine how to transform the Pharo integer, given the many different forms in which it could be rendered.
 
-Consider that in the case of C integers, a number can be signed or unsigned, and can occupy different sizes such as 8, 16, 32, or 64 bits.  Pharo can't guess; the C function expects a specific type to be provided, and the Pharo object containing the value doesn't reflect this.  We have to explicitly \'type\' the literal when we type it in.
+Consider that in the case of C integers, a number can be signed or unsigned, and can occupy different sizes such as 8, 16, 32, or 64 bits.  Pharo can\'t guess; the C function expects a specific type to be provided, and the Pharo object containing the value doesn\'t reflect this.  We have to explicitly \'type\' the literal when we type it in.
 
 We will present more detail about the different data types accepted by uFFI, in particular integer data types, in an upcoming section of this chapter.
 
@@ -270,7 +270,7 @@ SmallInteger >> absoluteValue [
 ]
 ]]]
 
-It is is also possible to pass instance variables, but we'll let you experiment with that as an exercise... \:\^)
+It is is also possible to pass instance variables, but we\'ll let you experiment with that as an exercise... \:\^)
 
 !!! uFFI Data Types
 
@@ -300,7 +300,7 @@ FFICExamples class >> stringLength: aString [
 You may have noticed that the callout description is not exactly the same as the C function header.
 
 In the signature ==#( int strlen (String aString) )== there are two differences with the C signature.
-- The first difference is the const keyword of the argument. For those not used to C, that's only a modifier keyword that the compiler takes into account to make some static validations at compile time. It has no value when describing the signature for calling a function at runtime.
+- The first difference is the const keyword of the argument. For those not used to C, that\'s only a modifier keyword that the compiler takes into account to make some static validations at compile time. It has no value when describing the signature for calling a function at runtime.
 - The second difference, an important one, is the specification of the argument. It is declared as ==String aString== instead of ==char * aString==. With ==String aString==, FFI-NB will automatically do the arguments conversion from Smalltalk strings to C strings (null terminated). Therefore it is important to use String and not ==char *==. In the example, the string passed will be put in an external C ==char== array and a null termination character will be added to it. Also, this array will be automatically released after the call ends. This automatic memory management is very useful but we can also control it as we will see later. Using ==(String aString)== is equivalent to ==(someString copyWith: (Character value:0)== as in ==FFICExamples stringLength: (someString copyWith: (Character value:0)==. Conversely, FFI-NB will take the C result value of calling the C function and convert it to a proper Smalltalk Integer in this particular case.
 
 !!! Passing two strings

--- a/Chapters/2-marshalling.pillar
+++ b/Chapters/2-marshalling.pillar
@@ -55,7 +55,7 @@ As we saw with return values in Chapter 1, Pharo's uFFI also manages the transfo
 To illustrate how marshalling works, let\'s consider the marshalling of a Pharo ==SmallInteger== to a C ==int== type, as in our example.
 Internally, for efficiency purposes, Pharo represents ==SmallInteger==s directly in binary, rather than as an object pointed to in the heap.  Therefore, to differentiate integers from object pointers, Pharo tags ==SmallInteger== \"pointers\" with an extra bit to signify this special interpretation.
 
-Let\'s consider the ==SmallInteger 2==; this value is represented in binary as the number ==2r10==, but is internally represented in Pharo as ==2r101==, where the ''least'' significant bit is shifted in as the added tag.  Since all Pharo object pointers are at least 32-bit aligned, we're guaranteed that their least significant bit will always be zero.  This makes a non-zero LSB a reliable indicator that we're dealing with a ==SmallInteger== rather than a heap pointer.  This is also why Pharo ==SmallInteger==s are 31 bits, ''not'' 32.
+Consider the ==SmallInteger 2==; this value is represented in binary as the number ==2r10==, but is internally represented in Pharo as ==2r101==, where the ''least'' significant bit is shifted in as the added tag.  Since all Pharo object pointers are at least 32-bit aligned, we're guaranteed that their least significant bit will always be zero.  This makes a non-zero LSB a reliable indicator that we're dealing with a ==SmallInteger== rather than a heap pointer.  This is also why Pharo ==SmallInteger==s are 31 bits, ''not'' 32.
 
 This resulting ''representation mismatch'' requires that the uFFI transform small integers to C ==int==s (and vice\-versa) as follows:
 - a Pharo small integer transformed to a C value needs to be logically shifted to the right, ==2r101 >> 1==, transforming ==2r101== to ==2r10==.
@@ -66,7 +66,7 @@ This resulting ''representation mismatch'' requires that the uFFI transform smal
 When marshalling Pharo objects to C, uFFI decides the transformation rule to use depending on two pieces of information.
 First, it considers the concrete type of the marshalled Pharo object, ''its class''.
 Second, it considers the C type defined in the function binding as the target transformation type.
-At run time, when the binding method is executed, uFFI reads the type of the binding argument and transforms the argument object to the indicated C type's representation, performing a type cast/coercion as necessary.
+At run time, when the binding method is executed, uFFI reads the type of the binding argument and transforms the argument object into the indicated C type representation, performing a type cast/coercion as necessary.
 
 These transformation rules have several consequences, which we will illustrate with several cases, using our previous ==abs:== binding example.
 
@@ -80,7 +80,7 @@ FFITutorial abs: -42.
 - Pharo integers that overflow the C ==int== size are coerced by truncating to size, producing results similar to what a C program would produce\:
 
 [[[language=smalltalk
-FFITutorial abs: SmallInteger maxVal.  "Cast to all 1\'s"
+FFITutorial abs: SmallInteger maxVal.  "Cast to all 1's"
 => 1
 ]]]
 
@@ -184,11 +184,11 @@ To provide for this, uFFI supports the usage of literal arguments in function bi
 
 [[[language=smalltalk
 FFITutorial class >> absMinusFortyTwo [
-	^ self ffiCall: #( int abs ( (int) -42 ) )
+	^ self ffiCall: #( int abs ( int -42 ) )
 ]
 ]]]
 
-Notice that we don't just type in a Pharo integer for the expected argument; literal values such as integers must be preceded by a C type declaration, such as the ==(int)== above, in parenthesis (to make it clear to the parser that it\'s a ''type specifier'').
+Notice that we don't just type in a Pharo integer for the expected argument; literal values such as integers must be preceded by a C type declaration, such as the ==int== above.
 This type information is needed by uFFI to correctly determine how to transform the Pharo integer, given the many different forms in which it could be rendered.
 
 Consider that in the case of C integers, a number can be signed or unsigned, and can occupy different sizes such as 8, 16, 32, or 64 bits.  Pharo can't guess; the C function expects a specific type to be provided, and the Pharo object containing the value doesn't reflect this.  We have to explicitly \'type\' the literal when we type it in.
@@ -216,7 +216,7 @@ Object subclass: #FFITutorial
   ...
 
 FFITutorial class >> initialize [
-	"Set this to -42 because.. Life, the Universe, and Everything"
+	"Set this to -42 because.. Life, the Universe, and Everything."
 	TheAnswer := -42.
 ]
 ]]]
@@ -225,14 +225,14 @@ Finally, we update our call\-out binding to use our class variable \-\- and note
 
 [[[language=smalltalk
 FFITutorial class >> absMinusFortyTwo [
-  ^ self ffiCall: #( int abs ( (int) TheAnswer) )
+  ^ self ffiCall: #( int abs ( int TheAnswer) )
 ]
 ]]]
 
 Just as with class variables, uFFI integrates transparently with variables defined in shared pools.
 Shared pools are useful for grouping common constants that need to be shared between different classes, bindings, or even libraries.
 
-The following code illustrates how we can modify our code to put our variable(s) in a shared pool.
+The following code illustrates how we can modify our code to put our variable in a shared pool.
 Notice that the only code that changes is the class defining the variable.
 The binding using the variable remains unchanged.
 
@@ -243,7 +243,7 @@ SharedPool subclass: #FFITutorialPool
   ...
 
 FFITutorialPool class >> initialize [
-	"Set this to -42 because.. Life, the Universe, and Everything"
+	"Set this to -42 because.. Life, the Universe, and Everything."
 	TheAnswer := -42.
 ]
 
@@ -253,7 +253,7 @@ Object subclass: #FFITutorial
   ...
 
 FFITutorial class >> absMinusFortyTwo [
-  ^ self ffiCall: #( int abs ( (int) TheAnswer ) )
+  ^ self ffiCall: #( int abs ( int TheAnswer ) )
 ]
 ]]]
 
@@ -270,7 +270,7 @@ SmallInteger >> absoluteValue [
 ]
 ]]]
 
-It is is also possible to pass instance variables, but we let you experiment with that as an exercise... \:\^)
+It is is also possible to pass instance variables, but we'll let you experiment with that as an exercise... \:\^)
 
 !!! uFFI Data Types
 


### PR DESCRIPTION
Removes Pillar escapes from code blocks (mainly Chapter 1).  
Removes the ( ) from type specs used with literal integers and variable names.
Edited up to Section 2.3.